### PR TITLE
Track build number in absence of Subversion metadata

### DIFF
--- a/engine/version.sh
+++ b/engine/version.sh
@@ -39,6 +39,10 @@ function get_revnum {
     fi
   elif git svn info >/dev/null 2>&1; then
     VERSION_BUILD=`git svn info | grep "Last Changed Rev" | sed s/Last\ Changed\ Rev:\ //g`
+  elif test -d "../.git" || test -d ".git"; then
+    VERSION_BUILD=`git rev-list --count HEAD`
+  elif test -d "../.hg" || test -d ".hg"; then
+    VERSION_BUILD=$((`hg id -n` + 1))
   fi
 }
 


### PR DESCRIPTION
OpenBOR was converted from Subversion to Git sometime ago. As Git didn't introduce new commits figuring out svn revision is as simple as summing up the number of git commits.
```
$ svn log -r4432 https://svn.code.sf.net/p/openbor/engine/engine/
------------------------------------------------------------------------
r4432 | whitedragon0000 | 2017-01-25 23:40:08 +0000 (Wed, 25 Jan 2017) | 1 line

added shadowopacity {-2 or -1 or 0~255} to level next prop
```
```
$ git rev-list --count ba1eb4f62cec
4432
$ git log -1 ba1eb4f62cec
commit ba1eb4f62cec7b4526bf2821e2681ad1c37df145
Author: whitedragon0000 <whitedragon0000@47506847-fb4f-4ee6-b66f-4fd32c0f12a1>
Date:   Wed Jan 25 23:40:08 2017 +0000

    added shadowopacity {-2 or -1 or 0~255} to level next prop
```
