### PR TITLE
Property access rework

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15374,7 +15374,7 @@ void load_level(char *filename)
             }
             break;
         case CMD_LEVEL_ITEMMAP:
-            next.itemmap = GET_INT_ARG(1);
+            next.item_properties.colorset = GET_INT_ARG(1);
             break;
         case CMD_LEVEL_ITEMHEALTH:
             next.itemhealth = GET_INT_ARG(1);
@@ -23768,9 +23768,9 @@ entity *drop_driver(entity *e)
     {
         strcpy(p.itemalias, e->item->alias);
 
-        p.item_properties.index = e->item->index;
-        p.itemmap           = e->item->colorset;
-        p.item_properties.alpha         = e->item->alpha;
+        p.item_properties.index     = e->item->index;
+        p.item_properties.colorset  = e->item->colorset;
+        p.item_properties.alpha     = e->item->alpha;
         p.itemhealth        = e->item->health;
         p.itemplayer_count  = e->item->player_count;
     }
@@ -31525,9 +31525,9 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
             strncpy(ent->item->alias, spawn_entry->itemalias, MAX_NAME_LEN);
         }
 
-        if(spawn_entry->itemmap)
+        if(spawn_entry->item_properties.colorset)
         {
-            ent->item->colorset = spawn_entry->itemmap;
+            ent->item->colorset = spawn_entry->item_properties.colorset;
         }
 
         if(spawn_entry->itemhealth)

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15343,16 +15343,16 @@ void load_level(char *filename)
             {
                 // Item to be contained by new entry
             case CMD_LEVEL_ITEM:
-                next.itemplayer_count = 0;
+                next.item_properties.player_count = 0;
                 break;
             case CMD_LEVEL_2PITEM:
-                next.itemplayer_count = 1;
+                next.item_properties.player_count = 1;
                 break;
             case CMD_LEVEL_3PITEM:
-                next.itemplayer_count = 2;
+                next.item_properties.player_count = 2;
                 break;
             case CMD_LEVEL_4PITEM:
-                next.itemplayer_count = 3;
+                next.item_properties.player_count = 3;
                 break;
             default:
                 assert(0);
@@ -23768,11 +23768,11 @@ entity *drop_driver(entity *e)
     {
         strcpy(p.itemalias, e->item->alias);
 
-        p.item_properties.index     = e->item->index;
-        p.item_properties.colorset  = e->item->colorset;
-        p.item_properties.alpha     = e->item->alpha;
+        p.item_properties.index         = e->item->index;
+        p.item_properties.colorset      = e->item->colorset;
+        p.item_properties.alpha         = e->item->alpha;
         p.itemhealth        = e->item->health;
-        p.itemplayer_count  = e->item->player_count;
+        p.item_properties.player_count  = e->item->player_count;
     }
 
 
@@ -31534,7 +31534,7 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
         {
             ent->item->health = spawn_entry->itemhealth;
         }
-        ent->item->player_count = spawn_entry->itemplayer_count;
+        ent->item->player_count = spawn_entry->item_properties.player_count;
     }
 }
 

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15409,7 +15409,7 @@ void load_level(char *filename)
             break;
         case CMD_LEVEL_ITEMTRANS:
         case CMD_LEVEL_ITEMALPHA:
-            next.itemtrans = GET_INT_ARG(1);
+            next.item_properties.alpha = GET_INT_ARG(1);
             break;
         case CMD_LEVEL_COORDS:
             next.position.x = GET_FLOAT_ARG(1);
@@ -23770,7 +23770,7 @@ entity *drop_driver(entity *e)
 
         p.item_properties.index = e->item->index;
         p.itemmap           = e->item->colorset;
-        p.itemtrans         = e->item->alpha;
+        p.item_properties.alpha         = e->item->alpha;
         p.itemhealth        = e->item->health;
         p.itemplayer_count  = e->item->player_count;
     }
@@ -31626,9 +31626,9 @@ entity *smartspawn(s_spawn_entry *props)      // 7-1-2005 Entire section replace
     {
         e->modeldata.aggression = props->aggression;    // Aggression can be changed with spawn points now
     }
-    if(props->itemtrans)
+    if(props->item_properties.alpha)
     {
-        e->item->alpha = props->itemtrans;
+        e->item->alpha = props->item_properties.alpha;
     }
     if(props->alpha)
     {

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -17087,10 +17087,10 @@ void free_ent(entity *e)
     free_all_scripts(&e->scripts);
 
     // Item properties.
-    if(e->item)
+    if(e->item_properties)
     {
-        free(e->item);
-        e->item = NULL;
+        free(e->item_properties);
+        e->item_properties = NULL;
     }
 
     if(e->waypoints)
@@ -23692,18 +23692,18 @@ entity *drop_item(entity *e)
 
     // Just to make sure there is an item so
     // we don't look for data on a NULL pointer.
-    if(!e->item)
+    if(!e->item_properties)
     {
         return NULL;
     }
 
-    p.index         = e->item->index;
+    p.index         = e->item_properties->index;
     p.item_properties.index = p.weaponindex = -1;
-    strcpy(p.alias, e->item->alias);
+    strcpy(p.alias, e->item_properties->alias);
     p.position.y    = e->position.y + 0.01; // For check, or an enemy "item" will drop from the sky
-    p.health[0]     = e->item->health;
-    p.alpha         = e->item->alpha;
-    p.colourmap     = e->item->colorset;
+    p.health[0]     = e->item_properties->health;
+    p.alpha         = e->item_properties->alpha;
+    p.colourmap     = e->item_properties->colorset;
     p.flip          = e->direction;
 
     item = smartspawn(&p);
@@ -23764,15 +23764,15 @@ entity *drop_driver(entity *e)
 
     // Carrying an item, so let's transfer that to spawn
     // entry for the driver.
-    if(e->item)
+    if(e->item_properties)
     {
-        strcpy(p.item_properties.alias, e->item->alias);
+        strcpy(p.item_properties.alias, e->item_properties->alias);
 
-        p.item_properties.index         = e->item->index;
-        p.item_properties.colorset      = e->item->colorset;
-        p.item_properties.alpha         = e->item->alpha;
-        p.item_properties.health        = e->item->health;
-        p.item_properties.player_count  = e->item->player_count;
+        p.item_properties.index         = e->item_properties->index;
+        p.item_properties.colorset      = e->item_properties->colorset;
+        p.item_properties.alpha         = e->item_properties->alpha;
+        p.item_properties.health        = e->item_properties->health;
+        p.item_properties.player_count  = e->item_properties->player_count;
     }
 
 
@@ -23815,9 +23815,9 @@ void checkdeath()
     }
 
     // Drop an item if we have one.
-    if(self->item)
+    if(self->item_properties)
     {
-        if(count_ents(TYPE_PLAYER) > self->item->player_count)
+        if(count_ents(TYPE_PLAYER) > self->item_properties->player_count)
         {
             drop_item(self);
         }
@@ -31506,35 +31506,35 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
     // if there is already memory for an item allocated
     // here, clear it out to make sure we don't end up
     // with any memory leaks.
-    if(ent->item)
+    if(ent->item_properties)
     {
-       free(ent->item);
-       ent->item = NULL;
+       free(ent->item_properties);
+       ent->item_properties = NULL;
     }
 
     // Allocate memory for the item.
-    ent->item = malloc(sizeof(*ent->item));
-    memset(ent->item, 0, sizeof(*ent->item));
+    ent->item_properties = malloc(sizeof(*ent->item_properties));
+    memset(ent->item_properties, 0, sizeof(*ent->item_properties));
 
     if(spawn_entry)
     {
-        ent->item->index = spawn_entry->item_properties.index;
+        ent->item_properties->index = spawn_entry->item_properties.index;
 
         if(spawn_entry->item_properties.alias[0])
         {
-            strncpy(ent->item->alias, spawn_entry->item_properties.alias, MAX_NAME_LEN);
+            strncpy(ent->item_properties->alias, spawn_entry->item_properties.alias, MAX_NAME_LEN);
         }
 
         if(spawn_entry->item_properties.colorset)
         {
-            ent->item->colorset = spawn_entry->item_properties.colorset;
+            ent->item_properties->colorset = spawn_entry->item_properties.colorset;
         }
 
         if(spawn_entry->item_properties.health)
         {
-            ent->item->health = spawn_entry->item_properties.health;
+            ent->item_properties->health = spawn_entry->item_properties.health;
         }
-        ent->item->player_count = spawn_entry->item_properties.player_count;
+        ent->item_properties->player_count = spawn_entry->item_properties.player_count;
     }
 }
 
@@ -31628,7 +31628,7 @@ entity *smartspawn(s_spawn_entry *props)      // 7-1-2005 Entire section replace
     }
     if(props->item_properties.alpha)
     {
-        e->item->alpha = props->item_properties.alpha;
+        e->item_properties->alpha = props->item_properties.alpha;
     }
     if(props->alpha)
     {

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15380,7 +15380,7 @@ void load_level(char *filename)
             next.itemhealth = GET_INT_ARG(1);
             break;
         case CMD_LEVEL_ITEMALIAS:
-            strncpy(next.itemalias, GET_ARG(1), MAX_NAME_LEN);
+            strncpy(next.item_properties.alias, GET_ARG(1), MAX_NAME_LEN);
             break;
         case CMD_LEVEL_WEAPON:
             //spawn with a weapon 2007-2-12 by UTunnels
@@ -23766,7 +23766,7 @@ entity *drop_driver(entity *e)
     // entry for the driver.
     if(e->item)
     {
-        strcpy(p.itemalias, e->item->alias);
+        strcpy(p.item_properties.alias, e->item->alias);
 
         p.item_properties.index         = e->item->index;
         p.item_properties.colorset      = e->item->colorset;
@@ -31520,9 +31520,9 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
     {
         ent->item->index = spawn_entry->item_properties.index;
 
-        if(spawn_entry->itemalias[0])
+        if(spawn_entry->item_properties.alias[0])
         {
-            strncpy(ent->item->alias, spawn_entry->itemalias, MAX_NAME_LEN);
+            strncpy(ent->item->alias, spawn_entry->item_properties.alias, MAX_NAME_LEN);
         }
 
         if(spawn_entry->item_properties.colorset)

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15234,7 +15234,7 @@ void load_level(char *filename)
             // Back to defaults
             next.spawnplayer_count = 0;
             memset(&next, 0, sizeof(next));
-            next.index = next.itemindex = next.weaponindex = -1;
+            next.index = next.item_properties.index = next.weaponindex = -1;
             // Name of entry to be spawned
             // Load model (if not loaded already)
             cached_model = findmodel(GET_ARG(1));
@@ -15370,7 +15370,7 @@ void load_level(char *filename)
             if(tempmodel)
             {
                 next.item = tempmodel->name;
-                next.itemindex = get_cached_model_index(next.item);
+                next.item_properties.index = get_cached_model_index(next.item);
             }
             break;
         case CMD_LEVEL_ITEMMAP:
@@ -23698,7 +23698,7 @@ entity *drop_item(entity *e)
     }
 
     p.index         = e->item->index;
-    p.itemindex     = p.weaponindex = -1;
+    p.item_properties.index = p.weaponindex = -1;
     strcpy(p.alias, e->item->alias);
     p.position.y    = e->position.y + 0.01; // For check, or an enemy "item" will drop from the sky
     p.health[0]     = e->item->health;
@@ -23768,7 +23768,7 @@ entity *drop_driver(entity *e)
     {
         strcpy(p.itemalias, e->item->alias);
 
-        p.itemindex         = e->item->index;
+        p.item_properties.index = e->item->index;
         p.itemmap           = e->item->colorset;
         p.itemtrans         = e->item->alpha;
         p.itemhealth        = e->item->health;
@@ -31518,7 +31518,7 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
 
     if(spawn_entry)
     {
-        ent->item->index = spawn_entry->itemindex;
+        ent->item->index = spawn_entry->item_properties.index;
 
         if(spawn_entry->itemalias[0])
         {
@@ -31715,7 +31715,7 @@ void spawnplayer(int index)
     memset(&p, 0, sizeof(p));
     p.name = player[index].name;
     p.index = -1;
-    p.itemindex = -1;
+    p.item_properties.index = -1;
     p.weaponindex = -1;
     p.colourmap = player[index].colourmap;
     p.spawnplayer_count = -1;

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15377,7 +15377,7 @@ void load_level(char *filename)
             next.item_properties.colorset = GET_INT_ARG(1);
             break;
         case CMD_LEVEL_ITEMHEALTH:
-            next.itemhealth = GET_INT_ARG(1);
+            next.item_properties.health = GET_INT_ARG(1);
             break;
         case CMD_LEVEL_ITEMALIAS:
             strncpy(next.item_properties.alias, GET_ARG(1), MAX_NAME_LEN);
@@ -23771,7 +23771,7 @@ entity *drop_driver(entity *e)
         p.item_properties.index         = e->item->index;
         p.item_properties.colorset      = e->item->colorset;
         p.item_properties.alpha         = e->item->alpha;
-        p.itemhealth        = e->item->health;
+        p.item_properties.health        = e->item->health;
         p.item_properties.player_count  = e->item->player_count;
     }
 
@@ -31530,9 +31530,9 @@ void initialize_item_carry(entity *ent, s_spawn_entry *spawn_entry)
             ent->item->colorset = spawn_entry->item_properties.colorset;
         }
 
-        if(spawn_entry->itemhealth)
+        if(spawn_entry->item_properties.health)
         {
-            ent->item->health = spawn_entry->itemhealth;
+            ent->item->health = spawn_entry->item_properties.health;
         }
         ent->item->player_count = spawn_entry->item_properties.player_count;
     }

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2459,7 +2459,6 @@ typedef struct
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
     s_item_properties item_properties; // Alias, health, index, etc. for items.
-        int itemmap;
         int itemplayer_count; // spawn the item according to the amount of players
         char itemalias[MAX_NAME_LEN + 1];
         int itemhealth;

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2448,26 +2448,26 @@ typedef struct
     u32 musicoffset;
     char *name; // must be a name in the model list, so just reference
     int index; // model index
-    int itemindex; // item model index
     int weaponindex; // the spawned entity with an weapon item, this is the index of the item model
     int alpha; // Used for alpha effects
     int boss;
     int flip;
-    int itemtrans;
-    int itemmap;
     int colourmap;
     int dying; // Used for the dying flash animation
     int dying2; // Used for the dying flash animation health 25% (optional)
     unsigned per1; // Used to store at what health value the entity begins to flash
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
-    int itemplayer_count; // spawn the item according to the amount of players
+    s_item_properties item_properties; // Alias, health, index, etc. for items.
+        int itemtrans;
+        int itemmap;
+        int itemplayer_count; // spawn the item according to the amount of players
+        char itemalias[MAX_NAME_LEN + 1];
+        int itemhealth;
+    char *item; // must be a name in the model list, so just reference
     s_model *itemmodel;
     s_model *model;
     char alias[MAX_NAME_LEN + 1];
-    char *item; // must be a name in the model list, so just reference
-    char itemalias[MAX_NAME_LEN + 1];
-    int itemhealth;
     int health[MAX_PLAYERS];
     int mp; // mp's variable for mpbar by tails
     unsigned score; // So score can be overridden for enemies/obstacles

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2262,7 +2262,7 @@ typedef struct entity
     s_model             *defaultmodel;          // this is the default model
     s_model             *model;                 // current model
     s_model             modeldata;              // model data copied here
-    s_item_properties   *item;                  // Properties copied to an item entity when it is dropped.
+    s_item_properties   *item_properties;       // Properties copied to an item entity when it is dropped.
     bool boss;
     unsigned int dying;   // Corresponds with which remap is to be used for the dying flash
     unsigned int dying2;  // Corresponds with which remap is to be used for the dying flash for per2

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2459,7 +2459,6 @@ typedef struct
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
     s_item_properties item_properties; // Alias, health, index, etc. for items.
-        char itemalias[MAX_NAME_LEN + 1];
         int itemhealth;
     char *item; // must be a name in the model list, so just reference
     s_model *itemmodel;

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2459,7 +2459,6 @@ typedef struct
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
     s_item_properties item_properties; // Alias, health, index, etc. for items.
-        int itemhealth;
     char *item; // must be a name in the model list, so just reference
     s_model *itemmodel;
     s_model *model;

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2459,7 +2459,6 @@ typedef struct
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
     s_item_properties item_properties; // Alias, health, index, etc. for items.
-        int itemtrans;
         int itemmap;
         int itemplayer_count; // spawn the item according to the amount of players
         char itemalias[MAX_NAME_LEN + 1];

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2459,7 +2459,6 @@ typedef struct
     unsigned per2; // Used to store at what health value the entity flashes more rapidly
     int nolife; // So nolife can be overriden for all characters
     s_item_properties item_properties; // Alias, health, index, etc. for items.
-        int itemplayer_count; // spawn the item according to the amount of players
         char itemalias[MAX_NAME_LEN + 1];
         int itemhealth;
     char *item; // must be a name in the model list, so just reference

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -1802,11 +1802,11 @@ typedef struct
 typedef struct
 {
     bool                    antigrav;               // This animation ignores gravity.
-    unsigned int      animhits;               // How many consecutive hits have been made? Used for canceling.
-    unsigned int      chargetime;             // charge time for an animation
-    unsigned int      flipframe;              // Turns entities around on the desired frame
-    unsigned int      numframes;              // Count of frames in the animation.
-    unsigned int      unsummonframe;          // Un-summon the entity
+    int                     animhits;               // How many consecutive hits have been made? Used for canceling.
+    unsigned int            chargetime;             // charge time for an animation
+    int                     flipframe;              // Turns entities around on the desired frame
+    int                     numframes;              // Count of frames in the animation.
+    int                     unsummonframe;          // Un-summon the entity
     bool                    attackone;              // Attack hits only one target.
     int                     cancel;                 // Cancel anims with freespecial
     int                     index;                  // unique id
@@ -1830,8 +1830,8 @@ typedef struct
     float                   *starvelocity;          // 3 velocities for the start projectile
     int                     *sprite;                // sprite[set][framenumber]
     float                   *summonframe;           // Summon the subentity as an ally, only one though {frame} {x} {z} {a} {relative?}
-    unsigned int      *vulnerable;
-    unsigned int      *weaponframe;           // Specify with a frame when to switch to a weapon model
+    int                     *vulnerable;
+    int                     *weaponframe;           // Specify with a frame when to switch to a weapon model
     s_collision_attack_list **collision_attack;
     s_collision_body_list   **collision_body;
     s_counterrange          *counterrange;           // Auto counter attack. 2011_04_01, DC: Moved to struct.

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -9454,7 +9454,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
     case _sse_itemhealth:
         if(SUCCEEDED(ScriptVariant_IntegerValue(arg, &ltemp)))
         {
-            spawnentry.itemhealth = (int)ltemp;
+            spawnentry.item_properties.health = (int)ltemp;
         }
         else
         {

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -9407,7 +9407,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
         spawnentry.itemmodel = findmodel((char *)StrCache_Get(arg->strVal));
         spawnentry.item = spawnentry.itemmodel->name;
         spawnentry.item_properties.index = get_cached_model_index(spawnentry.item);
-        spawnentry.itemplayer_count = 0;
+        spawnentry.item_properties.player_count = 0;
         break;
     case _sse_2pitem:
         if(arg->vt != VT_STR)
@@ -9423,7 +9423,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
         {
             spawnentry.item = tempmodel->name;
         }
-        spawnentry.itemplayer_count = 1;
+        spawnentry.item_properties.player_count = 1;
         break;
     case _sse_3pitem:
         if(arg->vt != VT_STR)
@@ -9431,7 +9431,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
             goto setspawnentry_error;
         }
         spawnentry.itemmodel = findmodel((char *)StrCache_Get(arg->strVal));
-        spawnentry.itemplayer_count = 2;
+        spawnentry.item_properties.player_count = 2;
         break;
     case _sse_4pitem:
         if(arg->vt != VT_STR)
@@ -9439,7 +9439,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
             goto setspawnentry_error;
         }
         spawnentry.itemmodel = findmodel((char *)StrCache_Get(arg->strVal));
-        spawnentry.itemplayer_count = 3;
+        spawnentry.item_properties.player_count = 3;
         break;
     case _sse_health:
         if(SUCCEEDED(ScriptVariant_IntegerValue(arg, &ltemp)))

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -9271,7 +9271,7 @@ HRESULT openbor_clearspawnentry(ScriptVariant **varlist , ScriptVariant **pretva
 {
     *pretvar = NULL;
     memset(&spawnentry, 0, sizeof(spawnentry));
-    spawnentry.index = spawnentry.itemindex = spawnentry.weaponindex = -1;
+    spawnentry.index = spawnentry.item_properties.index = spawnentry.weaponindex = -1;
     return S_OK;
 }
 
@@ -9406,7 +9406,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
         }
         spawnentry.itemmodel = findmodel((char *)StrCache_Get(arg->strVal));
         spawnentry.item = spawnentry.itemmodel->name;
-        spawnentry.itemindex = get_cached_model_index(spawnentry.item);
+        spawnentry.item_properties.index = get_cached_model_index(spawnentry.item);
         spawnentry.itemplayer_count = 0;
         break;
     case _sse_2pitem:

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -9466,7 +9466,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
         {
             return E_FAIL;
         }
-        strcpy(spawnentry.itemalias, (char *)StrCache_Get(arg->strVal));
+        strcpy(spawnentry.item_properties.alias, (char *)StrCache_Get(arg->strVal));
         break;
     case _sse_2phealth:
         if(SUCCEEDED(ScriptVariant_IntegerValue(arg, &ltemp)))

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -9555,7 +9555,7 @@ HRESULT openbor_setspawnentry(ScriptVariant **varlist, ScriptVariant **pretvar, 
     case _sse_itemmap:
         if(SUCCEEDED(ScriptVariant_IntegerValue(arg, &ltemp)))
         {
-            spawnentry.itemmap = (int)ltemp;
+            spawnentry.item_properties.colorset = (int)ltemp;
         }
         else
         {


### PR DESCRIPTION
Item structure created for entity is now used in spawn entry structure as well. Besides readability and code base reuse, it also means script authors can use the future item property functions on either just by getting the pointer.