### PR TITLE
Debug performance fix

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -16759,11 +16759,11 @@ void predrawstatus()
     // Performance info.
     if(savedata.debuginfo)
     {
-        spriteq_add_box(0, videomodes.dOffset - 12, videomodes.hRes, videomodes.dOffset + 12, 0x0FFFFFFE, 0, NULL);
-        font_printf(2,                   videomodes.dOffset - 10, 0, 0, Tr("FPS: %03d"), getFPS());
-        font_printf(videomodes.hRes / 2, videomodes.dOffset - 10, 0, 0, Tr("Free Ram: %s KB"), commaprint(freeram / KBYTES));
-        font_printf(2,                   videomodes.dOffset,    0, 0, Tr("Sprites: %d / %d"), spriteq_get_sprite_count(), spriteq_get_sprite_max());
-        font_printf(videomodes.hRes / 2, videomodes.dOffset,    0, 0, Tr("Used Ram: %s KB"), commaprint(usedram / KBYTES));
+        spriteq_add_box(0, videomodes.dOffset - 12, videomodes.hRes, videomodes.dOffset + 12, LAYER_Z_LIMIT_BOX_MAX, 0, NULL);
+        font_printf(2,                   videomodes.dOffset - 10, 0, LAYER_Z_LIMIT_MAX, Tr("FPS: %03d"), getFPS());
+        font_printf(videomodes.hRes / 2, videomodes.dOffset - 10, 0, LAYER_Z_LIMIT_MAX, Tr("Free Ram: %s KB"), commaprint(freeram / KBYTES));
+        font_printf(2,                   videomodes.dOffset,    0, LAYER_Z_LIMIT_MAX, Tr("Sprites: %d / %d"), spriteq_get_sprite_count(), spriteq_get_sprite_max());
+        font_printf(videomodes.hRes / 2, videomodes.dOffset,    0, LAYER_Z_LIMIT_MAX, Tr("Used Ram: %s KB"), commaprint(usedram / KBYTES));
     }
 }
 

--- a/engine/source/gamelib/spriteq.h
+++ b/engine/source/gamelib/spriteq.h
@@ -15,6 +15,12 @@
 #define			SFX_BLEND		2
 #define			SFX_SPECIAL		3
 
+// Max layer values, used at debug performance menu
+#define			LAYER_Z_LIMIT_MAX		1410065407
+#define			LAYER_Z_LIMIT_BOX_MAX		0x540BE3FF
+
+
+
 extern int  pixelformat;
 // Sprite queueing and sorting
 void spriteq_add_sprite(int x, int y, int z, int id, s_drawmethod *pdrawmethod, int sortid);
@@ -37,4 +43,3 @@ void spriteq_clear(void);
 
 
 #endif
-


### PR DESCRIPTION
Fixed the text overlap in performance option in Debug Mode.

I've defined two new constants at spriteq.h

LAYER_Z_LIMIT_MAX (INT)
LAYER_Z_LIMIT_BOX_MAX (HEX)

Co-Authored-By: msmalik681 <31506138+msmalik681@users.noreply.github.com>