### PR TITLE
Wii velocity bug fix

### DIFF
--- a/engine/source/scriptlib/ScriptVariant.c
+++ b/engine/source/scriptlib/ScriptVariant.c
@@ -926,6 +926,7 @@ void ScriptVariant_Neg( ScriptVariant *svar)
     {
     case VT_DECIMAL:
         svar->dblVal = -(svar->dblVal);
+		break;
     case VT_INTEGER:
         svar->lVal = -(svar->lVal);
     default:


### PR DESCRIPTION
Bug that caused Wii port not to process "velocity" correctly bug fix from White Dragon.