### PR TITLE
Boss Kill Fix

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -31435,7 +31435,7 @@ void kill_all_enemies()
     entity *tmpself = NULL;
 
     attack = emptyattack;
-	attack.attack_type = ATK_NORMAL;
+	attack.attack_type = ATK_TIMEOVER;
     //attack.attack_type = max_attack_types - 1;
     attack.dropv.y = default_model_dropv.y;
     attack.dropv.x = default_model_dropv.x;


### PR DESCRIPTION
This is a temporary fix for killing all enemies when boss is killed to end the level.  If we use any other attack type and the boss has a helper using “defence all 0” this will result in the game getting stuck forever.