### PR TITLE
Support vsync

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -564,9 +564,9 @@ endif
 
 ifdef BUILD_SDL
 ifeq ($(findstring DGE, $(SDKPATH)), DGE)
-LIBS           += -lSDL -lSDL_gfx -lts
+LIBS           += -lSDL -lts
 else
-LIBS           += -Wl,-rpath,$(LIBRARIES) -lSDL2 -lSDL2_gfx
+LIBS           += -Wl,-rpath,$(LIBRARIES) -lSDL2
 endif
 endif
 

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -16202,7 +16202,8 @@ unsigned getFPS(void)
     lasttick = curtick;
     if(!framerate)
     {
-        return 0;
+        // if the frame took 0 ms, act like it was 1 ms instead
+        return 1000;
     }
 #ifdef PSP
     return ((10000000 / framerate) + 9) / 10;

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -2512,6 +2512,7 @@ void clearsettings()
     savedata.uselog = 1;
     savedata.debuginfo = 0;
     savedata.fullscreen = 0;
+    savedata.vsync = 1;
 
 	#if WII
     savedata.stretch = 1;
@@ -38986,22 +38987,25 @@ void menu_options_video()
         _menutext((selector == 7), col1, 4, Tr("Software Filter:"));
         _menutext((selector == 7), col2, 4, ((savedata.hwscale >= 2.0 || savedata.fullscreen) ? Tr(GfxBlitterNames[savedata.swfilter]) : Tr("Disabled")));
 
+        _menutext((selector == 8), col1, 5, Tr("VSync:"));
+        _menutext((selector == 8), col2, 5, savedata.vsync ? "Enabled" : "Disabled");
+
         if(savedata.fullscreen)
         {
-            _menutext((selector == 8), col1, 5, Tr("Fullscreen Type:"));
-            _menutext((selector == 8), col2, 5, (savedata.stretch ? Tr("Stretch to Screen") : Tr("Preserve Aspect Ratio")));
+            _menutext((selector == 9), col1, 6, Tr("Fullscreen Type:"));
+            _menutext((selector == 9), col2, 6, (savedata.stretch ? Tr("Stretch to Screen") : Tr("Preserve Aspect Ratio")));
         }
-        else if(selector == 8)
+        else if(selector == 9)
         {
-            selector = (bothnewkeys & FLAG_MOVEUP) ? 7 : 9;
+            selector = (bothnewkeys & FLAG_MOVEUP) ? 8 : 10;
         }
 
-        _menutextm((selector == 9), 7, 0, Tr("Back"));
+        _menutextm((selector == 10), 8, 0, Tr("Back"));
         if(selector < 0)
         {
-            selector = 9;
+            selector = 10;
         }
-        if(selector > 9)
+        if(selector > 10)
         {
             selector = 0;
         }
@@ -39281,6 +39285,10 @@ void menu_options_video()
 				video_set_mode(videomodes);
                 break;
             case 8:
+                savedata.vsync = !savedata.vsync;
+                video_set_mode(videomodes);
+                break;
+            case 9:
                 video_stretch((savedata.stretch ^= 1));
                 break;
 #endif

--- a/engine/sdl/opengl.c
+++ b/engine/sdl/opengl.c
@@ -254,7 +254,7 @@ int video_gl_set_mode(s_videomodes videomodes)
 	}
 
 	// try to disable vertical retrace syncing (VSync)
-	if(SDL_GL_SetSwapInterval(0) < 0)
+	if(SDL_GL_SetSwapInterval(!!savedata.vsync) < 0)
 	{
 		printf("Warning: can't disable vertical retrace sync (%s)...\n", SDL_GetError());
 	}

--- a/engine/sdl/opengl.c
+++ b/engine/sdl/opengl.c
@@ -19,7 +19,6 @@
 #include "opengl.h"
 #include "video.h"
 #include "loadgl.h"
-#include "SDL2_framerate.h"
 #include <math.h>
 
 #define nextpowerof2(x) pow(2,ceil(log(x)/log(2)))
@@ -39,7 +38,6 @@ static GLfloat tcx, tcy; // maximum x and y texture coords in floating-point for
 static GLuint shaderProgram; // fragment shader program
 
 // use some variables declared in video.c that are common to both backends
-extern FPSmanager framerate_manager;
 extern int stretch;
 extern int nativeWidth, nativeHeight;
 extern SDL_Window* window;
@@ -393,11 +391,6 @@ int video_gl_copy_screen(s_videosurface* surface)
 
 	// display the rendered frame on the screen
 	SDL_GL_SwapWindow(window);
-
-#if WIN || LINUX
-	// limit framerate to 200 fps
-	SDL_framerateDelay(&framerate_manager);
-#endif
 
 	return 1;
 }

--- a/engine/sdl/video.c
+++ b/engine/sdl/video.c
@@ -143,7 +143,7 @@ int SetVideoMode(int w, int h, int bpp, bool gl)
 
 	if(!gl)
 	{
-		renderer = SDL_CreateRenderer(window, -1, 0);
+		renderer = SDL_CreateRenderer(window, -1, savedata.vsync ? SDL_RENDERER_PRESENTVSYNC : 0);
 		if(!renderer)
 		{
 			printf("Error: failed to create renderer: %s\n", SDL_GetError());

--- a/engine/sdl/video.c
+++ b/engine/sdl/video.c
@@ -13,7 +13,6 @@
 #else
 
 #include "sdlport.h"
-#include "SDL2_framerate.h"
 
 #include <math.h>
 #include "types.h"
@@ -31,8 +30,6 @@
 SDL_Window *window = NULL;
 static SDL_Renderer *renderer = NULL;
 static SDL_Texture *texture = NULL;
-
-FPSmanager framerate_manager;
 
 s_videomodes stored_videomodes;
 yuv_video_mode stored_yuv_mode;
@@ -71,9 +68,6 @@ void initSDL()
 	nativeWidth = video_info.w;
 	nativeHeight = video_info.h;
 	printf("debug:nativeWidth, nativeHeight, bpp, Hz  %d, %d, %d, %d\n", nativeWidth, nativeHeight, SDL_BITSPERPIXEL(video_info.format), video_info.refresh_rate);
-
-	SDL_initFramerate(&framerate_manager);
-	SDL_setFramerate(&framerate_manager, 200);
 }
 
 void video_set_window_title(const char* title)
@@ -231,10 +225,6 @@ int video_copy_screen(s_screen* src)
 
 	SDL_UpdateTexture(texture, NULL, surface->data, surface->pitch);
 	blit();
-
-#if WIN || LINUX
-	SDL_framerateDelay(&framerate_manager);
-#endif
 
 	return 1;
 }

--- a/engine/source/savedata.h
+++ b/engine/source/savedata.h
@@ -38,6 +38,7 @@ typedef struct
     int fullscreen; // Window or Full Screen Mode
     int stretch; // Stretch (1) or preserve aspect ratio (0) in fullscreen mode
     int screen[1][2];
+    int vsync; // Sync to monitor refresh (1) or don't (0)
 #if SDL
     int usegl; // 1 if OpenGL is preferred over SDL software blitting
     float hwscale; // Scale factor for OpenGL


### PR DESCRIPTION
## General Description
Add support for vsync to synchronize the framerate to the monitor's refresh rate instead of using the SDL_gfx framerate manager to limit the framerate to 200 FPS. This saves energy and also lets us remove our dependency on SDL_gfx.