### PR TITLE
small bug fixes

### DIFF
--- a/engine/android/AndroidManifest.xml
+++ b/engine/android/AndroidManifest.xml
@@ -6,7 +6,7 @@
       android:installLocation="preferExternal">
 
     <!-- Android 4.4.2 -->
-    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="19" />
+    <uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />

--- a/engine/android/project.properties
+++ b/engine/android/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
+target=android-28

--- a/engine/android/zipaglin.bat
+++ b/engine/android/zipaglin.bat
@@ -1,0 +1,1 @@
+zipalign -v 4 bin\OpenBOR-release-unsigned.apk bin\OpenBOR-release-aligned.apk

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -21491,6 +21491,7 @@ void update_animation()
             self->update_mark |= UPDATE_MARK_UPDATE_ANIMATION; // frame updated, mark it
             // just switch frame to f, if frozen, expand_time will deal with it well
             update_frame(self, f);
+			bothnewkeys = 0; //stop mutiple skips.
         }
     }
 
@@ -39698,6 +39699,7 @@ void openborMain(int argc, char **argv)
     printf("Game Selected: %s\n\n", packfile);
     loadsettings();
     startup();
+	bothnewkeys = 0;
 
     if(skiptoset < 0)
     {

--- a/engine/source/gamelib/soundmix.c
+++ b/engine/source/gamelib/soundmix.c
@@ -543,7 +543,7 @@ static void mixaudio(unsigned int todo)
                 sptr16 = soundcache[snum].sample.sampleptr;
                 for(i = 0; i < (int)todo;)
                 {
-                    lmusic = rmusic = sptr16[FIX_TO_INT(fp_pos)];
+                    lmusic = rmusic = (int)(short)SwapLSB16(sptr16[FIX_TO_INT(fp_pos)]);
                     mixbuf[i++] += (lmusic * lvolume / MAXVOLUME);
                     if(vchannel[chan].channels == SOUND_MONO)
                     {


### PR DESCRIPTION
disable some keys to stop logo.fig being skipped after selecting a pak from the menu and stop mutiple skips when using a text entity.

Wii port fix for the 16-bit samples playing static noise full credit to @whitedragon0000  for this fix.

Android added zipalign batch file to align a app before signing. Target API put up to 28 so apps can be uploaded to google play store.

# Pull Request

## General Description
Replace this text with a description of the changes and purpose. If the pull request resolves an issue, please cite the issue Example: Fixes #<issue number>.
