### PR TITLE
Switch to e_animations for ICMPSCONSTA

### DIFF
--- a/engine/source/openborscript/constants.c
+++ b/engine/source/openborscript/constants.c
@@ -780,8 +780,8 @@ int mapstrings_transconst(ScriptVariant **varlist, int paramCount)
         ICMPSCONSTA(ANI_BACKDIE, animbackdies)
         ICMPSCONSTA(ANI_BACKRISE, animbackrises)
         ICMPSCONSTA(ANI_BACKRISEATTACK, animbackriseattacks)
-        ICMPSCONSTA(ANI_BLOCKPAIN, blkpains)
-        ICMPSCONSTA(ANI_BACKBLOCKPAIN, backblkpains)
+        ICMPSCONSTA(ANI_BLOCKPAIN, animblkpains)
+        ICMPSCONSTA(ANI_BACKBLOCKPAIN, animbackblkpains)
 
         // Animation properties.
         ICMPCONST(ANI_PROP_ANIMHITS)

--- a/engine/source/openborscript/scriptcommon.h
+++ b/engine/source/openborscript/scriptcommon.h
@@ -109,8 +109,8 @@ extern int            *animbackfalls;
 extern int            *animbackdies;
 extern int            *animbackrises;
 extern int            *animbackriseattacks;
-extern int            *blkpains;
-extern int            *backblkpains;
+extern int            *animblkpains;
+extern int            *animbackblkpains;
 
 extern int            noshare;
 extern int            credits;


### PR DESCRIPTION
Other animation constants are stored in variables with `anim` prefix. Fixes #138, see [build log](https://github.com/DCurrent/openbor/files/3139804/openbor-6997.log).

CC @Plombo 

