### PR TITLE
Simplified Android Build Process

### DIFF
--- a/engine/android/README
+++ b/engine/android/README
@@ -15,7 +15,7 @@ For 2, you can name your package name freely. Normally will be your domain name 
 
 # Sideload more mods
 
-In case you want to install mods in order to play the game, you have to sideload by putting your `.pak` files on to external storage `OpenBOR/Paks/` locating on Anroid device. This will work with OpenBOR built as general purpose (see 1. above)
+In case you want to install mods in order to play the game, you have to sideload by putting your `.pak` files on to external storage `OpenBOR/Paks/` locating on Android device. This will work with OpenBOR built as general purpose (see 1. above)
 
 # Android development with OpenBOR
 
@@ -26,20 +26,33 @@ There are a couple of things to note when develop your game with OpenBOR on Andr
 
 ## 100 MB assets limitation
 
-Android limits the maximum size of assets that can be embeded into a single .apk file at 100 MB.
+Android limits the maximum size of assets that can be embedded into a single .apk file at 100 MB.
 Most likely if your game's assets are quite big, it will get pass through such limit i.e. World Heroes Timeless (https://github.com/DCurrent/World-Heroes-Timeless) .pak file is at 72 MB mark.
 
 During development, you have no worry about this file size limit. It will only be imposed when you planned to publish on Play Store, so you will have to spend some effort following their policy which will affect end-users downloading your app. See expansion files (obb) https://developer.android.com/google/play/expansion-files.html for further instruction on how to do this.
 
 Anyway for debugging and development, you can
 
-* normally put .pak file into `app/src/main/res/raw` directory (remember to rename it to bor.png). But you might have to increase gradle's heap memory to accomodate processing the file. Configure gradle's heap memory at `gradle.properties` at line `org.gradle.jvmargs=-Xmx1536m` (for example, change to 4GB, change it to `org.gradle.jvmargs=-Xmx4096m`)
+* normally put .pak file into `app/src/main/res/raw` directory (remember to rename it to bor.png). But you might have to increase gradle's heap memory to accommodate processing the file. Configure gradle's heap memory at `gradle.properties` at line `org.gradle.jvmargs=-Xmx1536m` (for example, change to 4GB, change it to `org.gradle.jvmargs=-Xmx4096m`)
 * build OpenBOR and install on device normally without .pak file. Manually place such file to device via any possible means at `Paks/` of your application. You might need to root your device doing this as it's visible to application not end-users. Also name your .pak file as <versionName>.pak in which <versionName> is `android:versionName` value as seen in `AndroidManifest.xml` located at `app/src/main/`.
 
 # Build instruction
 
 * Download relevant Android SDK and NDK then and set up `ANDROID_HOME`, and `ANDROID_NDK_HOME` environment variables properly.
-* Execute `./gradlew installDebug` it will build and `.apk` then intall it on your connected Android device.
+* Execute `./gradlew installDebug` it will build and `.apk` then install it on your connected Android device.
+
+## Msmalik681 Windows 10 Build instructions
+
+* First get the Android SDK. Download from "https://developer.android.com/studio" the command line tools only package for windows and save it to "C:/android/sdk" folder (if you do not have this path make it). Extract the tools folder here. Now you can run the file "sdk-setup.bat" and it should download everything you need (if your sdk folder is in a different location edit the "sdk-setup.bat" to point to yours).
+* Second Download the JAVA JDK from "https://www.oracle.com/technetwork/java/javase/downloads/jdk12-downloads-5295953.html" for windows x64 exe and install it.
+* Now you can setup your environment variables first set your "user variable":
+	"ANDROID_HOME" = "C:\android\sdk"
+  Now setup System Variables -> Path add these lines:
+	"C:\Program Files\Java\jdk1.8.0_202\bin" (note "jdk1.8.0_202" this folder may be different based on your version installed)
+	"C:\android\sdk\tools\bin"
+	"C:\android\sdk\build-tools\28.0.3"
+	"C:\android\sdk\ndk-bundle"
+  Now restart your PC.  To test the NDK open command prompt and type "ndk-build" and for java type "java -version" if they are recognized commands your all set.
 
 # Note
 
@@ -49,3 +62,9 @@ You can see some common source/header files in `android-gradle/` are sym-link fi
 
 * Minimum SDK (API Level) is 19 at the moment, we possibly lower this down to 14 for both ant and gradle build. Marked to check this back later.
 * Currently focus to build only for `armeabi-v7a`, we should also build for others i.e. `arm64-v8a`, `x86` and `x86_64` but that means we need to bundle pre-built dependencies (libraries) as well i.e. SDL2, etc.
+
+# Custom Apk instructions
+
+* First make a keystore key using the "make.my.key.bat" first right click and edit the .bat file to modify the "alias_name" to your preferred alias then run. Complete all the details keeping note of the passwords they can be different but I like to keep them the same. finally you will get a output file "my-key.jks" in the same directory keep this file safe as you will need it to sign your apks.
+* Next open the file "app/build.gradle" and modify the "MODFY FOR CUSTOM APK" and the "SIGNING FOR CUSTOM APK" fields to match your games details make sure the passwords match your "my-key.jks" file.
+* Now edit the "build.bat" file and make sure it is set to " cmd /k "gradlew.bat clean & gradlew.bat assembleRelease" " ignoring the outer quotes I used here. Run build.bat and if completed successfully your apk will be at "app/build/outputs/apk/release/app-release.apk" your can rename the apk if you want to and now your ready to upload your app.

--- a/engine/android/app/build.gradle
+++ b/engine/android/app/build.gradle
@@ -1,25 +1,18 @@
-/*
-def buildAsLibrary = project.hasProperty('BUILD_AS_LIBRARY');
-def buildAsApplication = !buildAsLibrary
-if (buildAsApplication) {
-    apply plugin: 'com.android.application'
-}
-else {
-*/
-    //apply plugin: 'com.android.library'
 	apply plugin: 'com.android.application'
-//}
 	
 android {
     compileSdkVersion 28
     defaultConfig {
-        /*if (buildAsApplication) {
-            applicationId "org.openbor.engine"
-        }*/
         minSdkVersion 19
         targetSdkVersion 28
+		
+		//////////// MODFY FOR CUSTOM APK /////////////////
+		applicationId "org.openbor.engine"
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
+		resValue "string", "app_name", "Openbor"
+		///////////////////////////////////////////////////
+		
         externalNativeBuild {
             ndkBuild {
                 arguments "APP_PLATFORM=android-19"
@@ -31,12 +24,25 @@ android {
         }
     }
 	
+	signingConfigs {
+    release {
+		//////////// SIGNING FOR CUSTOM APK ////////////////
+		keyAlias "alias_name"
+		keyPassword "password"
+		storeFile file("C:/openbor/engine/android/my-key.jks")
+		storePassword "password"
+		///////////////////////////////////////////////////
+		} 
+	}
+	
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+			signingConfig signingConfigs.release
         }
     }
+	
     if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
         sourceSets.main {
             jniLibs.srcDir 'libs'
@@ -48,22 +54,10 @@ android {
         }
        
     }
+	
     lintOptions {
         abortOnError false
     }
-    
-    /*if (buildAsLibrary) {
-        libraryVariants.all { variant ->
-            variant.outputs.each { output ->
-                //def outputFile = 
-				output.outputFile
-                if (output.outputFile != null && output.outputFile.name.endsWith(".aar")) {
-                    def fileName = "org.openbor.engine";
-                    output.outputFile = new File(output.outputFile.parent, fileName);
-                }
-            }
-        }
-    }*/
 }
 
 dependencies {

--- a/engine/android/app/src/main/res/values/strings.xml
+++ b/engine/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">OpenBOR</string>
+<!--
+    <string name="app_name">Punch Man</string>
+-->
 </resources>

--- a/engine/android/build.bat
+++ b/engine/android/build.bat
@@ -1,4 +1,4 @@
-gradlew.bat clean assembleDebug
+cmd /k "gradlew.bat clean & gradlew.bat assembleDebug"
 @rem clean
 @rem assembleRelease
 @rem assembleDebug

--- a/engine/android/make.my.key.bat
+++ b/engine/android/make.my.key.bat
@@ -1,0 +1,1 @@
+keytool -genkey -v -keystore my-key.jks -alias alias_name -keyalg RSA -keysize 2048 -validity 10000

--- a/engine/android/sdk-setup.bat
+++ b/engine/android/sdk-setup.bat
@@ -1,0 +1,2 @@
+cmd /k " C:\android\sdk\tools\bin\sdkmanager.bat "build-tools;28.0.3" "ndk-bundle" "platform-tools" "platforms;android-28" "tools" "
+@rem sdkmanager.bat --list


### PR DESCRIPTION
Modified build so "app/build.gradle" file just needs to be modified to make a custom APK.  Added instruction in the README file to build on windows 10 and how to make a custom APK.  Added option to make your keystore file to sign your play store apps.