### PR TITLE
Quick improve Android build related to keystore.properties

### DIFF
--- a/engine/android/app/build.gradle
+++ b/engine/android/app/build.gradle
@@ -1,68 +1,71 @@
 apply plugin: 'com.android.application'
 
-def keystorePropertiesFile = rootProject.file("keystore.properties")
-def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+android {
+  compileSdkVersion 28
+    defaultConfig {
+      minSdkVersion 19
+        targetSdkVersion 28
 
-  android {
-    compileSdkVersion 28
-      defaultConfig {
-        minSdkVersion 19
-          targetSdkVersion 28
+        //////////// MODFY FOR CUSTOM APK /////////////////
+        applicationId "org.openbor.engine"
+        versionCode 1
+        versionName "1.0.0"
+        resValue "string", "app_name", "Openbor"
+        ///////////////////////////////////////////////////
 
-          //////////// MODFY FOR CUSTOM APK /////////////////
-          applicationId "org.openbor.engine"
-          versionCode 1
-          versionName "1.0.0"
-          resValue "string", "app_name", "Openbor"
-          ///////////////////////////////////////////////////
-
-          externalNativeBuild {
-            ndkBuild {
-              arguments "APP_PLATFORM=android-19"
-                // for now focus on armeabi-v7a
-                // for other abis, we need to also pre-compile and build other libraries
-                //abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-                abiFilters 'armeabi-v7a'
-            }
+        externalNativeBuild {
+          ndkBuild {
+            arguments "APP_PLATFORM=android-19"
+              // for now focus on armeabi-v7a
+              // for other abis, we need to also pre-compile and build other libraries
+              //abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+              abiFilters 'armeabi-v7a'
           }
-      }
-
-    signingConfigs {
-      release {
-        keyAlias keystoreProperties['keyAlias']
-          keyPassword keystoreProperties['keyPassword']
-          storeFile file(keystoreProperties['storeFile'])
-          storePassword keystoreProperties['storePassword']
-      } 
-    }
-
-    buildTypes {
-      release {
-        minifyEnabled false
-          proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-          signingConfig signingConfigs.release
-      }
-    }
-
-    if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
-      sourceSets.main {
-        jniLibs.srcDir 'libs'
-      }
-      externalNativeBuild {
-        ndkBuild {
-          path 'jni/Android.mk'
         }
-      }
-
     }
 
-    lintOptions {
-      abortOnError false
+  signingConfigs {
+    release {
+      // only try to find keystore.properties when it's release build
+      if (project.gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') }) {
+        def keystorePropertiesFile = rootProject.file("keystore.properties")
+        def keystoreProperties = new Properties()
+        keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
+        keyAlias keystoreProperties['keyAlias']
+        keyPassword keystoreProperties['keyPassword']
+        storeFile file(keystoreProperties['storeFile'])
+        storePassword keystoreProperties['storePassword']
+      }
+    } 
+  }
+
+  buildTypes {
+    release {
+      minifyEnabled false
+        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        signingConfig signingConfigs.release
     }
   }
 
+  if (!project.hasProperty('EXCLUDE_NATIVE_LIBS')) {
+    sourceSets.main {
+      jniLibs.srcDir 'libs'
+    }
+    externalNativeBuild {
+      ndkBuild {
+        path 'jni/Android.mk'
+      }
+    }
+
+  }
+
+  lintOptions {
+    abortOnError false
+  }
+}
+
 dependencies {
-  implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation "com.android.support:support-v4:27.0.2"
+implementation fileTree(include: ['*.jar'], dir: 'libs')
+  implementation "com.android.support:support-v4:27.0.2"
 }


### PR DESCRIPTION
# Pull Request

## General Description
Quick fix for Android build not to have gradle looking at `keystore.properties` file and failed if users try to build for debug build, only release build it will try to look for such file.

In short, this PR fixes the mistake in which gradle is still trying to look for `keystore.properties` file even in Debug build.
