### PR TITLE
Wiimpathy Updates

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -489,6 +489,8 @@ endif
 
 ifdef BUILD_WII
 CFLAGS 	       += -DCACHE_BACKGROUNDS -DREVERSE_COLOR -D__ppc__ $(MACHDEP) -Wl,-Map,$(TARGET_MAP),-wrap,wiiuse_register
+# This allows to compile with DevkitPPC r29 and above.
+CFLAGS 	       += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
 endif
 
 

--- a/engine/source/globals.h
+++ b/engine/source/globals.h
@@ -53,6 +53,9 @@
 #include <gctypes.h>
 #include <ogc/conf.h>
 #include "wiiport.h"
+// For devkitPPC r29+
+#define stricmp strcasecmp
+#define strnicmp strncasecmp
 #endif
 
 #ifdef VITA

--- a/engine/wii/menu.c
+++ b/engine/wii/menu.c
@@ -220,34 +220,43 @@ void refreshInput()
 	if(gcbtns & PAD_BUTTON_RIGHT)                         btns |= DIR_RIGHT;
 
 	// Controller buttons
-	if(wpad->btns_h & WPAD_BUTTON_1)                      btns |= WIIMOTE_1;
-	if(wpad->btns_h & WPAD_BUTTON_2)                      btns |= WIIMOTE_2;
-	if(wpad->btns_h & WPAD_BUTTON_A)                      btns |= WIIMOTE_A;
-	if(wpad->btns_h & WPAD_BUTTON_B)                      btns |= WIIMOTE_B;
-	if(wpad->btns_h & WPAD_BUTTON_MINUS)                  btns |= WIIMOTE_MINUS;
-	if(wpad->btns_h & WPAD_BUTTON_PLUS)                   btns |= WIIMOTE_PLUS;
-	if(wpad->btns_h & WPAD_BUTTON_HOME)                   btns |= WIIMOTE_HOME;
-	if(wpad->btns_h & WPAD_NUNCHUK_BUTTON_Z)              btns |= NUNCHUK_Z;
-	if(wpad->btns_h & WPAD_NUNCHUK_BUTTON_C)              btns |= NUNCHUK_C;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_A)              btns |= CC_A;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_B)              btns |= CC_B;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_Y)              btns |= CC_Y;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_X)              btns |= CC_X;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_MINUS)          btns |= CC_MINUS;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)           btns |= CC_PLUS;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME)           btns |= CC_HOME;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R)         btns |= CC_R;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L)         btns |= CC_L;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_ZL)             btns |= CC_ZL;
-	if(wpad->btns_h & WPAD_CLASSIC_BUTTON_ZR)             btns |= CC_ZR;
-	if(gcbtns & PAD_BUTTON_X)                             btns |= GC_X;
-	if(gcbtns & PAD_BUTTON_Y)                             btns |= GC_Y;
-	if(gcbtns & PAD_BUTTON_A)                             btns |= GC_A;
-	if(gcbtns & PAD_BUTTON_B)                             btns |= GC_B;
-	if(gcbtns & PAD_TRIGGER_R)                            btns |= GC_R;
-	if(gcbtns & PAD_TRIGGER_L)                            btns |= GC_L;
-	if(gcbtns & PAD_TRIGGER_Z)                            btns |= GC_Z;
-	if(gcbtns & PAD_BUTTON_START)                         btns |= GC_START;
+	if(wpad->exp.type <= WPAD_EXP_NUNCHUK)
+	{
+		if(wpad->btns_h & WPAD_BUTTON_1)                      btns |= WIIMOTE_1;
+		if(wpad->btns_h & WPAD_BUTTON_2)                      btns |= WIIMOTE_2;
+		if(wpad->btns_h & WPAD_BUTTON_A)                      btns |= WIIMOTE_A;
+		if(wpad->btns_h & WPAD_BUTTON_B)                      btns |= WIIMOTE_B;
+		if(wpad->btns_h & WPAD_BUTTON_MINUS)                  btns |= WIIMOTE_MINUS;
+		if(wpad->btns_h & WPAD_BUTTON_PLUS)                   btns |= WIIMOTE_PLUS;
+		if(wpad->btns_h & WPAD_BUTTON_HOME)                   btns |= WIIMOTE_HOME;
+		if(wpad->btns_h & WPAD_NUNCHUK_BUTTON_Z)              btns |= NUNCHUK_Z;
+		if(wpad->btns_h & WPAD_NUNCHUK_BUTTON_C)              btns |= NUNCHUK_C;
+	}
+	else if(wpad->exp.type == WPAD_EXP_CLASSIC)
+	{
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_A)              btns |= CC_A;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_B)              btns |= CC_B;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_Y)              btns |= CC_Y;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_X)              btns |= CC_X;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_MINUS)          btns |= CC_MINUS;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_PLUS)           btns |= CC_PLUS;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_HOME)           btns |= CC_HOME;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_R)         btns |= CC_R;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_FULL_L)         btns |= CC_L;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_ZL)             btns |= CC_ZL;
+		if(wpad->btns_h & WPAD_CLASSIC_BUTTON_ZR)             btns |= CC_ZR;
+	}
+	else
+	{
+		if(gcbtns & PAD_BUTTON_X)                             btns |= GC_X;
+		if(gcbtns & PAD_BUTTON_Y)                             btns |= GC_Y;
+		if(gcbtns & PAD_BUTTON_A)                             btns |= GC_A;
+		if(gcbtns & PAD_BUTTON_B)                             btns |= GC_B;
+		if(gcbtns & PAD_TRIGGER_R)                            btns |= GC_R;
+		if(gcbtns & PAD_TRIGGER_L)                            btns |= GC_L;
+		if(gcbtns & PAD_TRIGGER_Z)                            btns |= GC_Z;
+		if(gcbtns & PAD_BUTTON_START)                         btns |= GC_START;
+	}
 
 	// update buttons pressed (not held)
 	buttonsPressed = btns & ~buttonsHeld;
@@ -346,12 +355,14 @@ static int findPaks(void)
 				fileliststruct *copy = NULL;
 				if(filelist == NULL) filelist = malloc(sizeof(fileliststruct));
 				else
+				{
 					copy = malloc(i * sizeof(fileliststruct));
 					memcpy(copy, filelist, i * sizeof(fileliststruct));
 					free(filelist);
 					filelist = malloc((i + 1) * sizeof(fileliststruct));
 					memcpy(filelist, copy, i * sizeof(fileliststruct));
 					free(copy); copy = NULL;
+				}
 				memset(&filelist[i], 0, sizeof(fileliststruct));
 				strcpy(filelist[i].filename, ds->d_name);
 				i++;
@@ -761,58 +772,64 @@ void Menu()
 	setVideoMode();
 	drawLogo();
 
-	dListTotal = findPaks();
-	dListCurrentPosition = 0;
-	if(dListTotal != 1)
+	// Skips menu if we already have a .pak to load
+	int quicklaunch = (packfile[0] == '\0') ? 0 : 1;
+
+	if(!quicklaunch)
 	{
-		sortList();
-		getAllLogs();
-		initMenu(1);
-		drawMenu();
-		pControl = ControlMenu;
-
-		while(!done)
+		dListTotal = findPaks();
+		dListCurrentPosition = 0;
+		if(dListTotal != 1)
 		{
-			ctrl = Control();
-			switch(ctrl)
+			sortList();
+			getAllLogs();
+			initMenu(1);
+			drawMenu();
+			pControl = ControlMenu;
+
+			while(!done)
 			{
-				case 1:
-					if (dListTotal > 0) done = 1;
-					break;
+				ctrl = Control();
+				switch(ctrl)
+				{
+					case 1:
+						if (dListTotal > 0) done = 1;
+						break;
 
-				case 2:
-					done = 1;
-					break;
+					case 2:
+						done = 1;
+						break;
 
-				case 3:
-					drawLogs();
-					break;
+					case 3:
+						drawLogs();
+						break;
 
-				case -1:
-					drawMenu();
-					break;
+					case -1:
+						drawMenu();
+						break;
 
-				case -2:
-					// BGM player isn't supported
-					break;
+					case -2:
+						// BGM player isn't supported
+						break;
 
-                default:
-					break;
+		            default:
+						break;
+				}
+			}
+			freeAllLogs();
+			termMenu();
+			if(ctrl == 2)
+			{
+				if (filelist)
+				{
+					free(filelist);
+					filelist = NULL;
+				}
+				borExit(0);
 			}
 		}
-		freeAllLogs();
-		termMenu();
-		if(ctrl == 2)
-		{
-			if (filelist)
-			{
-				free(filelist);
-				filelist = NULL;
-			}
-			borExit(0);
-		}
+		getBasePath(packfile, filelist[dListCurrentPosition+dListScrollPosition].filename, 1);
 	}
-	getBasePath(packfile, filelist[dListCurrentPosition+dListScrollPosition].filename, 1);
 	free(filelist);
 }
 

--- a/engine/wii/wiiport.c
+++ b/engine/wii/wiiport.c
@@ -18,6 +18,7 @@
 #include "menu.h"
 #include <fat.h>
 
+extern void __exception_setreload(int t);
 
 char packfile[MAX_FILENAME_LEN];
 char paksDir[MAX_FILENAME_LEN];
@@ -57,38 +58,67 @@ void initDirPath(char* dest, char* relPath)
 
 int main(int argc, char * argv[])
 {
-    int retry = 0;
-
+	// Launch a pak directly from a loader with plugin ability(Wiiflow, Postloader etc).
+	// With WiiFlow, the first definable plugin's argument in openbor.ini is argv[1].
+	int directlaunch = (argc > 1 && (argv[1][0] == 'u' || argv[1][0] == 's')) ? 1 : 0;
+	
 	video_init();
 
-// use libfat for FAT filesystem access
-	while (!fatInitDefault() && retry < 12)
+	// Reset after 8 seconds after a crash
+	__exception_setreload(8);
+
+	// reload to IOS58 for USB2 support
+	if (IOS_GetVersion() != 58)
+	{       
+        IOS_ReloadIOS(58);
+	}
+
+	// use libfat for FAT filesystem access
+	int retry = 0;
+	int fatMounted = 0;
+
+	// try to mount FAT devices during 3 seconds
+	while (!fatMounted && (retry < 12))
 	{
-	    usleep(250000);
-	    retry++;
+		fatMounted = fatInitDefault();
+		usleep(250000);
+		retry++;
 	}
 
 	setSystemRam();
 	packfile_mode(0);
-
 	
-//new system to get base directory on usb or sd.
-
+	//new system to get base directory on usb or sd.
 	char root[MAX_FILENAME_LEN];
 	memset(root, '\0', sizeof(root));
-	strncpy(root, argv[0], strrchr(argv[0], '/') - argv[0]);
 	
-		sprintf(rootDir, "%s/", root);
-		sprintf(savesDir, "%s/Saves", root);
-		sprintf(paksDir,"%s/Paks", root);
-		sprintf(logsDir, "%s/Logs", root);
-		sprintf(screenShotsDir, "%s/ScreenShots", root);
+	// Root path sent by the loader's argument(apps/OpenBOR by default)
+	if(directlaunch)
+	{
+		strncpy(root, argv[1], strrchr(argv[1], '/') - argv[1]);
+	}
+	else
+	{
+		strncpy(root, argv[0], strrchr(argv[0], '/') - argv[0]);
+	}
+
+	sprintf(rootDir, "%s/", root);
+	sprintf(savesDir, "%s/Saves", root);
+	sprintf(paksDir,"%s/Paks", root);
+	sprintf(logsDir, "%s/Logs", root);
+	sprintf(screenShotsDir, "%s/ScreenShots", root);
 		
 
 	dirExists(paksDir, 1);
 	dirExists(savesDir, 1);
 	dirExists(logsDir, 1);
 	dirExists(screenShotsDir, 1);
+	
+	// Pack's name sent by the loader's argument
+	if(directlaunch)
+	{
+		getBasePath(packfile, argv[2], 1);
+	}
 
 	Menu();
 	openborMain(argc, argv);


### PR DESCRIPTION
Various updates from Wiimpathy.

- Add devkitPPC r29+ compatibility.
-Add loader's arguments support. Load games with WiiFlow etc.
-Fix Wii Classic Controller dpad in menu.
-Fix a crash when loaded from USB without SD and with a device in port 1.
