### PR TITLE
Improve Logging

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15974,7 +15974,13 @@ void load_level(char *filename)
     totalram = getSystemRam(BYTES);
     freeram = getFreeRam(BYTES);
     usedram = getUsedRam(BYTES);
-    printf("Total Ram: %11"PRIu64" Bytes\n Free Ram: %11"PRIu64" Bytes\n Used Ram: %11"PRIu64" Bytes\n", totalram, freeram, usedram);
+    printf("Total Ram: %11"PRIu64" Bytes ( %5"PRIu64" MB )\n Free Ram: %11"PRIu64" Bytes ( %5"PRIu64" iB )\n Used Ram: %11"PRIu64" Bytes ( %5"PRIu64" MB )\n",
+        totalram,
+        totalram >> 20,
+        freeram,
+        freeram >> 20,
+        usedram,
+        usedram >> 20);
     printf("Total sprites mapped: %d\n\n", sprites_loaded);
 
 lCleanup:

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -15974,7 +15974,7 @@ void load_level(char *filename)
     totalram = getSystemRam(BYTES);
     freeram = getFreeRam(BYTES);
     usedram = getUsedRam(BYTES);
-    printf("Total Ram: %"PRIu64" Bytes\n Free Ram: %"PRIu64" Bytes\n Used Ram: %"PRIu64" Bytes\n", totalram, freeram, usedram);
+    printf("Total Ram: %11"PRIu64" Bytes\n Free Ram: %11"PRIu64" Bytes\n Used Ram: %11"PRIu64" Bytes\n", totalram, freeram, usedram);
     printf("Total sprites mapped: %d\n\n", sprites_loaded);
 
 lCleanup:

--- a/engine/source/ramlib/ram.c
+++ b/engine/source/ramlib/ram.c
@@ -236,7 +236,7 @@ u64 getUsedRam(int byte_size)
 
 void getRamStatus(int byte_size)
 {
-    printf("Total Ram: %"PRIu64" Bytes\n Free Ram: %"PRIu64" Bytes\n Used Ram: %"PRIu64" Bytes\n\n",
+    printf("Total Ram: %11"PRIu64" Bytes\n Free Ram: %11"PRIu64" Bytes\n Used Ram: %11"PRIu64" Bytes\n\n",
            getSystemRam(byte_size),
            getFreeRam(byte_size),
            getUsedRam(byte_size));

--- a/engine/source/ramlib/ram.c
+++ b/engine/source/ramlib/ram.c
@@ -236,9 +236,13 @@ u64 getUsedRam(int byte_size)
 
 void getRamStatus(int byte_size)
 {
-    printf("Total Ram: %11"PRIu64" Bytes\n Free Ram: %11"PRIu64" Bytes\n Used Ram: %11"PRIu64" Bytes\n\n",
-           getSystemRam(byte_size),
-           getFreeRam(byte_size),
-           getUsedRam(byte_size));
+  u64 system_ram = getSystemRam(byte_size);
+  u64 free_ram = getFreeRam(byte_size);
+  u64 used_ram = getUsedRam(byte_size);
+
+  printf("Total Ram: %11"PRIu64" Bytes ( %5"PRIu64" MB )\n Free Ram: %11"PRIu64" Bytes ( %5"PRIu64" MB )\n Used Ram: %11"PRIu64" Bytes ( %5"PRIu64" MB )\n\n",
+           system_ram, system_ram >> 20,
+           free_ram, free_ram >> 20,
+           used_ram, used_ram >> 20);
 }
 

--- a/engine/version.sh
+++ b/engine/version.sh
@@ -26,25 +26,11 @@ if [ `echo $HOST_PLATFORM | grep -o "windows"` ]; then
 fi
 }
 
-# Support the Bazaar VCS as an alternative to SVN through the bzr-svn plugin
 function get_revnum {
-  if test -d "../.svn" || test -d "./.svn"; then
-    VERSION_BUILD=`svn info | grep "Last Changed Rev" | sed s/Last\ Changed\ Rev:\ //g`
-  elif test -d ".bzr"; then
-    VERSION_BUILD=`bzr version-info | grep "svn-revno" | sed 's/svn-revno: //g'`
-    if [ ! $VERSION_BUILD ]; then # use non-SVN revision number if "svn-revno" property not available
-      REVNO=`bzr version-info | grep "revno:" | sed 's/revno: //g'`
-      BRANCH=`bzr version-info | grep "branch-nick:" | sed 's/branch-nick: //g'`
-      VERSION_BUILD=$REVNO-bzr-$BRANCH
-    fi
-  elif git svn info >/dev/null 2>&1; then
-    VERSION_BUILD=`git svn info | grep "Last Changed Rev" | sed s/Last\ Changed\ Rev:\ //g`
-  elif test -d "../.git" || test -d ".git"; then
+  if test -d "../.git" || test -d ".git"; then
     VERSION_BUILD=`git rev-list --count HEAD`
     # get commit hash, 7 chars in length is enough, and still work when supply as URL on github.com
     VERSION_COMMIT=`git rev-parse HEAD | cut -c -7`
-  elif test -d "../.hg" || test -d ".hg"; then
-    VERSION_BUILD=$((`hg id -n` + 1))
   fi
 }
 


### PR DESCRIPTION
# Pull Request

## General Description
* Improved showing commit hash in opening opebor's menu, and inside the log file (such commit hash reduced to 7 chars in length which is enough and can be directly put into browser to directly access such commit on github.com)
* Improved showing ram status with right-aligned along with human-readable unit

Example see below

**Commit hash shown in menu UI**
![Screenshot from 2019-05-18 02-55-50](https://user-images.githubusercontent.com/673757/57952003-6d39e000-791e-11e9-88b8-8874e105a566.png)

**Inside log file**
![Screenshot from 2019-05-18 03-39-53](https://user-images.githubusercontent.com/673757/57952064-a3775f80-791e-11e9-9ed4-be5bd34550d6.png)

# Further dev note

* Should we remove code for other version control applications inside `version.sh`? As now OpenBOR focuses and is only hosted on github. Showing commit hash is only available for git.
