### PR TITLE
Improve Cross-compile support for Windows build on Linux

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -569,7 +569,9 @@ ifdef BUILD_SDL
 ifeq ($(findstring DGE, $(SDKPATH)), DGE)
 LIBS           += -lSDL -lts
 else
-LIBS           += -Wl,-rpath,$(LIBRARIES) -lSDL2
+COMMA		=,
+RPATH_LIBS	= $(addprefix -Wl$(COMMA)-rpath$(COMMA),"$(LIBRARIES)")
+LIBS	       += $(RPATH_LIBS) -lSDL2
 endif
 endif
 

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -55,8 +55,10 @@ BUILDING        = 1
 YASM 	        = yasm$(EXTENSION)
 CC              = $(WINDEV)/$(PREFIX)gcc$(EXTENSION)
 INCLUDES        = $(SDKPATH)/include \
-                  $(SDKPATH)/include/SDL2
-LIBRARIES       = $(SDKPATH)/lib
+                  $(SDKPATH)/include/SDL2 \
+		  $(EXTRA_INCLUDES)
+LIBRARIES       = $(SDKPATH)/lib \
+		  $(EXTRA_LIBRARIES)
 ARCHFLAGS       = -m32
 ifeq ($(findstring 86, $(TARGET_ARCH)), 86)
 BUILD_MMX       = 1
@@ -572,6 +574,11 @@ else
 COMMA		=,
 RPATH_LIBS	= $(addprefix -Wl$(COMMA)-rpath$(COMMA),"$(LIBRARIES)")
 LIBS	       += $(RPATH_LIBS) -lSDL2
+
+ifdef CROSSCOMPILE_LINUX_WIN
+LIBS	       += -lsetupapi
+endif
+
 endif
 endif
 
@@ -615,6 +622,9 @@ endif
 
 ifdef BUILD_WEBM
 LIBS           += -lvpx
+ifdef CROSSCOMPILE_LINUX_WIN
+LIBS	       += -lpthread
+endif
 endif
 
 

--- a/engine/build.sh
+++ b/engine/build.sh
@@ -214,10 +214,15 @@ function windows {
     make clean BUILD_WIN=1
 		#first remove old resource file and update with build number from build_number.h.
 		if test -e "resources/OpenBOR.res"; then
-		rm "resources/OpenBOR.res";
-		windres.exe resources/OpenBOR.rc -o resources/OpenBOR.res -O coff
+			rm "resources/OpenBOR.res";
+		fi
+
+		# if it's cross-compile for Windows from Linux, then
+		# find a proper tool
+		if test -e "/usr/bin/i686-w64-mingw32-gcc" && test -e "/usr/bin/i686-w64-mingw32-windres"; then
+			i686-w64-mingw32-windres resources/OpenBOR.rc -o resources/OpenBOR.res -O coff
 		else
-		windres.exe resources/OpenBOR.rc -o resources/OpenBOR.res -O coff
+			windres.exe resources/OpenBOR.rc -o resources/OpenBOR.res -O coff
 		fi
     make BUILD_WIN=1
     if test -f "./OpenBOR.exe"; then

--- a/engine/environ.sh
+++ b/engine/environ.sh
@@ -195,7 +195,13 @@ case $1 in
 #                                                                          #
 ############################################################################
 5)
-   if test -e "/usr/i586-mingw32msvc"; then
+   if test -e "/usr/bin/i686-w64-mingw32-gcc"; then
+     export WINDEV=/usr/bin
+     export SDKPATH=/usr/lib/gcc/i686-w64-mingw32
+     export PREFIX=i686-w64-mingw32-
+     export PATH=$WINDEV:$PATH
+     export CROSSCOMPILE_LINUX_WIN=1
+   elif test -e "/usr/i586-mingw32msvc"; then
      export WINDEV=/usr/bin
      export SDKPATH=/usr/i586-mingw32msvc
      export PREFIX=i586-mingw32msvc-


### PR DESCRIPTION
# Pull Request

## General Description
This will make it easier to do cross-compile for Windows build on Linux.

In short, users just need to compile all dependencies as usual, then supply their `include` and `lib` directory via 2 newly added variables when execute `./build.sh` as follows

```
EXTRA_INCLUDES="/my/deps/sdl2-win32/include/SDL2 /my/deps/zlib-win32/include" EXTRA_LIBRARIES="/my/deps/sdl2-win32/lib /my/deps/zlib-win32/lib" ./build.sh 5
```
