### PR TITLE
Android Update

### DIFF
--- a/engine/android/app/src/main/java/org/openbor/engine/GameActivity.java
+++ b/engine/android/app/src/main/java/org/openbor/engine/GameActivity.java
@@ -256,8 +256,8 @@ public class GameActivity extends SDLActivity {
           Toast.makeText(appCtx, toast, Toast.LENGTH_LONG).show();
           outFolder.mkdirs();
 
-          int resId = appCtx.getResources().getIdentifier("raw/bor", null, appCtx.getPackageName());
-          InputStream in = getResources().openRawResource(resId);
+		  //custom pak should be saved in "app\src\main\assets\bor.pak"
+		  InputStream in = ctx.getAssets().open("bor.pak");
           FileOutputStream out = new FileOutputStream(outFile);
 
           copyFile(in, out);

--- a/engine/android/build.bat
+++ b/engine/android/build.bat
@@ -1,3 +1,12 @@
+@setlocal
+@echo off
+cd ../
+set TOOLS=../tools/bin;../tools/7-Zip;../tools/svn/bin
+set PATH=%TOOLS%;%PATH%
+bash.exe version.sh
+cd android
+@endlocal
+@echo
 cmd /k "gradlew.bat clean & gradlew.bat assembleDebug"
 @rem clean
 @rem assembleRelease


### PR DESCRIPTION
Fixed issue with large PAK file not being copied they now need to be saved as "app\src\main\assets\bor.pak".  Changed build.bat to now generate version.h when cmopiling android build as this missing file would cause a crash.