### PR TITLE
Unbreak Clang build on PowerPC

### DIFF
--- a/engine/source/gamelib/borendian.h
+++ b/engine/source/gamelib/borendian.h
@@ -58,10 +58,10 @@ static __inline__ UInt16 Swap16(UInt16 x)
 #elif defined(__GNUC__) && (defined(__powerpc__) || defined(__ppc__))
 static __inline__ UInt16 Swap16(UInt16 x)
 {
-    UInt16 result;
+    UInt32 result;
 
     __asm__("rlwimi %0,%2,8,16,23" : "=&r" (result) : "0" (x >> 8), "r" (x));
-    return result;
+    return (UInt16)result;
 }
 #elif defined(__GNUC__) && (defined(__M68000__) || defined(__M68020__))
 static __inline__ UInt16 Swap16(UInt16 x)


### PR DESCRIPTION
`rlwimi` ["store the rotated data in GPR RA under control of a 32-bit generated mask"](https://www.ibm.com/support/knowledgecenter/ssw_aix_71/assembler/idalangref_rlwimi_rlimi_rotwrd_instrs.html)
Reported [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=243865). CC @pkubaj