### PR TITLE
API 14 - Ice Cream Sandwich 4.0.1 support

### DIFF
--- a/engine/android/app/build.gradle
+++ b/engine/android/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
   compileSdkVersion 28
     defaultConfig {
-      minSdkVersion 16
+      minSdkVersion 14
         targetSdkVersion 28
 
         //////////// MODFY FOR CUSTOM APK /////////////////


### PR DESCRIPTION
Added support for minimum API down to 14 (Ice Cream Sandwich 4.0.1) as this is the minimum supported by the NDK.