### PR TITLE
Fix gcc9 build breaks

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -36369,7 +36369,9 @@ void savelevelinfo()
         save->pSpawnmp[i] = player[i].spawnmp;
         save->pWeapnum[i] = player[i].weapnum;
         save->pColourmap[i] = player[i].colourmap;
+        OPENBOR_STRINGOP_TRUNCATION_WARN_OFF;
         strncpy(save->pName[i], player[i].name, MAX_NAME_LEN);
+        OPENBOR_STRINGOP_TRUNCATION_WARN_ON;
     }
     save->credits = credits;
     save->level = current_level;

--- a/engine/source/gamelib/packfile.c
+++ b/engine/source/gamelib/packfile.c
@@ -319,7 +319,9 @@ char *casesearch(const char *dir, const char *filepath)
     //if (entry != NULL && entry->d_name != NULL)
     if (entry != NULL)
     {
-        sprintf(fullpath, "%s/%s", dir, entry->d_name);
+        OPENBOR_FORMAT_TRUNCATION_WARN_OFF;
+        snprintf(fullpath, sizeof(fullpath), "%s/%s", dir, entry->d_name);
+        OPENBOR_FORMAT_TRUNCATION_WARN_ON;
     }
 
     if (closedir(d))

--- a/engine/source/globals.h
+++ b/engine/source/globals.h
@@ -98,6 +98,9 @@ memset((p)+(n), 0, sizeof(*(p)));
 p = realloc((p), sizeof(*(p))*(s));\
 memset((p)+(n), 0, sizeof(*(p))*((s)-(n)));
 
+/*
+ * credit: https://github.com/iponweb/luavela/blob/f34210c08cf459efb90d155688b44b47aea1b3e8/src/lj_def.h#L165 
+ */
 #if __GNUC__ >= 8
 #define OPENBOR_STRINGOP_TRUNCATION_WARN_OFF \
     _Pragma("GCC diagnostic push") \

--- a/engine/source/globals.h
+++ b/engine/source/globals.h
@@ -112,4 +112,16 @@ memset((p)+(n), 0, sizeof(*(p))*((s)-(n)));
 #define OPENBOR_STRINGOP_TRUNCATION_WARN_ON /* stub */
 #endif /* __GNUC__ >= 8 */
 
+#if __GNUC__ >= 8
+#define OPENBOR_FORMAT_TRUNCATION_WARN_OFF \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wformat-truncation\"")
+#define OPENBOR_FORMAT_TRUNCATION_WARN_ON \
+    _Pragma("GCC diagnostic pop")
+#else /* !(__GNUC__ >= 8)  */
+#define OPENBOR_FORMAT_TRUNCATION_WARN_OFF /* stub */
+#define OPENBOR_FORMAT_TRUNCATION_WARN_ON /* stub */
+#endif /* __GNUC__ >= 8 */
+
+
 #endif

--- a/engine/source/globals.h
+++ b/engine/source/globals.h
@@ -98,4 +98,15 @@ memset((p)+(n), 0, sizeof(*(p)));
 p = realloc((p), sizeof(*(p))*(s));\
 memset((p)+(n), 0, sizeof(*(p))*((s)-(n)));
 
+#if __GNUC__ >= 8
+#define OPENBOR_STRINGOP_TRUNCATION_WARN_OFF \
+    _Pragma("GCC diagnostic push") \
+    _Pragma("GCC diagnostic ignored \"-Wstringop-truncation\"")
+#define OPENBOR_STRINGOP_TRUNCATION_WARN_ON \
+    _Pragma("GCC diagnostic pop")
+#else /* !(__GNUC__ >= 8)  */
+#define OPENBOR_STRINGOP_TRUNCATION_WARN_OFF /* stub */
+#define OPENBOR_STRINGOP_TRUNCATION_WARN_ON /* stub */
+#endif /* __GNUC__ >= 8 */
+
 #endif

--- a/engine/source/preprocessorlib/pp_parser.c
+++ b/engine/source/preprocessorlib/pp_parser.c
@@ -714,7 +714,9 @@ HRESULT pp_parser_stringify(pp_parser *self)
             }
             else
             {
+                OPENBOR_STRINGOP_TRUNCATION_WARN_OFF;
                 strncat(self->token.theSource, source, 1);
+                OPENBOR_STRINGOP_TRUNCATION_WARN_ON;                
             }
 
             if(strlen(self->token.theSource) + 2 > MAX_TOKEN_LENGTH)


### PR DESCRIPTION
# Pull Request

## General Description
This pull request fixes gcc-9 (and potentially newer) build breaks by disabling specific checks in specific lines of the code. *Real* fixes would demand more experience with the code, which is something I don't have ATM. But it is great to be able to build with newer GCC versions on fresh installs.

Fixes #200.
