### PR TITLE
Fixed menu crash

### DIFF
--- a/engine/android/.gitignore
+++ b/engine/android/.gitignore
@@ -5,4 +5,4 @@
 /app/.externalNativeBuild
 /build
 /keystore.properties
-/my-key.jks
+*.jks

--- a/engine/android/build.sh
+++ b/engine/android/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# build the android apk !
+# 
+
+cd $(dirname $(readlink -f $0))
+cd ../
+./version.sh
+cd android
+./gradlew clean
+./gradlew assembleDebug

--- a/engine/source/globals.h
+++ b/engine/source/globals.h
@@ -28,7 +28,7 @@
 #define		MAX_FILENAME_LEN	256
 #define		MAX_LABEL_LEN       128
 
-#define MAX_MODS_NUM 100
+#define MAX_MODS_NUM 18
 
 #ifdef PSP
 #include <stdarg.h>

--- a/engine/version.sh
+++ b/engine/version.sh
@@ -31,11 +31,12 @@ function get_revnum {
     VERSION_BUILD=`git rev-list --count HEAD`
     # get commit hash, 7 chars in length is enough, and still work when supply as URL on github.com
     VERSION_COMMIT=`git rev-parse HEAD | cut -c -7`
-  else
-	VERSION_BUILD=0000
-	VERSION_COMMIT=0000000
+  else # manually add build number if missing
+	read -p "missing build numer please enter: " VERSION_BUILD
+	echo "VERSION_BUILD is set to: $VERSION_BUILD"
   fi
 }
+
 
 function read_version {
 check_git


### PR DESCRIPTION
Fixed crash when reaching the bottom of the menu when there are more then 18 paks in the paks folder. Added a prompt to manually enter build number if not detected. Added android build script for Linux users.
