### PR TITLE
December-2021 fixes

### DIFF
--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -2640,7 +2640,6 @@ typedef struct
     float jumpheight; // 28-12-2004	Jump height variable added per character
     int jumpmovex; // low byte: 0 default 1 flip in air, 2 move in air, 3 flip and move
     int jumpmovez; // 2nd byte: 0 default 1 zjump with flip(not implemented yet) 2 z jump move in air, 3 1+2
-    int jumpspecial; // Kratus (10-2021) 0 default 1 don't kill the "xyz" movement
     int walkoffmovex; // low byte: 0 default 1 flip in air, 2 move in air, 3 flip and move
     int walkoffmovez; // 2nd byte: 0 default 1 zjump with flip(not implemented yet) 2 z jump move in air, 3 1+2
     int grabfinish; // wait for grab animation to finish before do other actoins
@@ -2659,7 +2658,6 @@ typedef struct
     int falldie; // Play die animation?
     int globalmap; // use global palette for its colour map in 24bit mode
     int nopain;
-    int noshadow; // Kratus (10-2021) Temporarily disable shadow without losing entity's shadow configuration
     int summonkill; // kill it's summoned entity when died;  0. dont kill 1. kill summoned only 2. kill all spawned entity
     int combostyle;
     int blockpain;
@@ -2734,6 +2732,11 @@ typedef struct
     int backpain;
     int nohithead; // used to hit or not a platform with head also when you set a height
     int hitwalltype; // wall type to toggle hitwall animations
+
+    //Kratus (12-2021) Moved the new added properties to the end of the list for easy searching
+    int jumpspecial; // 0 default, 1 don't kill the "xyz" movement
+    int noshadow; // 0 default, 1 temporarily disable shadow without losing entity's shadow configuration
+
     e_ModelFreetype freetypes;
     s_scripts *scripts;
 

--- a/engine/openborscript.c
+++ b/engine/openborscript.c
@@ -2010,8 +2010,7 @@ HRESULT openbor_changemodelproperty(ScriptVariant **varlist , ScriptVariant **pr
 }
 
 // ===== getentityproperty =====
-// Kratus (10-2021) Make combostyle, grabflip, grabdistance and shadow properties accessible by script
-// Kratus (10-2021) Added the new jumpspecial and noshadow properties accessible by script
+// Kratus (12-2021) New properties accessible by script: combostyle, grabdistance, grabflip, jumpspecial, noshadow, shadow (edited)
 enum entityproperty_enum
 {
     _ep_a,
@@ -2221,6 +2220,7 @@ enum entityproperty_enum
 };
 
 // arranged list, for searching
+// Kratus (12-2021) Fixed property string names: "animation_handle" and "offscreen_noatk_factor"
 static const char *eplist[] =
 {
     "a",
@@ -2232,7 +2232,7 @@ static const char *eplist[] =
     "animal",
     "animating",
     "animation",
-    "animation.handle",
+    "animation_handle",
     "animationid",
     "animheight",
     "animhits",
@@ -2355,7 +2355,7 @@ static const char *eplist[] =
     "noshadow",
     "numweapons",
     "offense",
-    "offscreennoatkfactor",
+    "offscreen_noatk_factor",
     "offscreenkill",
     "opponent",
     "owner",
@@ -4051,18 +4051,6 @@ HRESULT openbor_getentityproperty(ScriptVariant **varlist , ScriptVariant **pret
         (*pretvar)->lVal = (LONG)ent->modeldata.gfxshadow;
         break;
     }
-    case _ep_shadow:
-    {
-        ScriptVariant_ChangeType(*pretvar, VT_INTEGER);
-        (*pretvar)->lVal = (LONG)ent->modeldata.shadow;
-        break;
-    }
-    case _ep_shadowbase:
-    {
-        ScriptVariant_ChangeType(*pretvar, VT_INTEGER);
-        (*pretvar)->lVal = (LONG)ent->modeldata.shadowbase;
-        break;
-    }
     case _ep_grabbing:
     {
         if(ent->grabbing) // always return an empty var if it is NULL
@@ -4972,6 +4960,18 @@ HRESULT openbor_getentityproperty(ScriptVariant **varlist , ScriptVariant **pret
     {
         ScriptVariant_ChangeType(*pretvar, VT_INTEGER);
         (*pretvar)->lVal = (LONG)ent->modeldata.setlayer;
+        break;
+    }
+    case _ep_shadow:
+    {
+        ScriptVariant_ChangeType(*pretvar, VT_INTEGER);
+        (*pretvar)->lVal = (LONG)ent->modeldata.shadow;
+        break;
+    }
+    case _ep_shadowbase:
+    {
+        ScriptVariant_ChangeType(*pretvar, VT_INTEGER);
+        (*pretvar)->lVal = (LONG)ent->modeldata.shadowbase;
         break;
     }
     case _ep_sortid:
@@ -6065,22 +6065,6 @@ HRESULT openbor_changeentityproperty(ScriptVariant **varlist , ScriptVariant **p
         }
         break;
     }
-    case _ep_shadow:
-    {
-        if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
-        {
-            ent->modeldata.shadow = (LONG)ltemp;
-        }
-        break;
-    }
-    case _ep_shadowbase:
-    {
-        if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
-        {
-            ent->modeldata.shadowbase = (LONG)ltemp;
-        }
-        break;
-    }
     case _ep_grabdistance:
     {
         if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
@@ -6857,6 +6841,22 @@ HRESULT openbor_changeentityproperty(ScriptVariant **varlist , ScriptVariant **p
         if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
         {
             ent->modeldata.setlayer = (LONG)ltemp;
+        }
+        break;
+    }
+    case _ep_shadow:
+    {
+        if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
+        {
+            ent->modeldata.shadow = (LONG)ltemp;
+        }
+        break;
+    }
+    case _ep_shadowbase:
+    {
+        if(SUCCEEDED(ScriptVariant_IntegerValue(varlist[2], &ltemp)))
+        {
+            ent->modeldata.shadowbase = (LONG)ltemp;
         }
         break;
     }

--- a/engine/source/openborscript/commands.c
+++ b/engine/source/openborscript/commands.c
@@ -196,7 +196,7 @@ List *createModelCommandList(void)
         LIST_ADD(CMD_MODEL_COLLISION_ETC, buf);
     }
 
-    // Kratus (10-2021) Added new jumpspecial and noshadow properties
+    // Kratus (12-2021) Added new jumpspecial and noshadow properties, put "noshadow" in alphabetical order
     LIST_ADD(CMD_MODEL_COLLISIONONE, "attackone");
     LIST_ADD(CMD_MODEL_ATTACKTHROTTLE, "attackthrottle");
     LIST_ADD(CMD_MODEL_COLLISIONZ, "attackz");
@@ -378,10 +378,10 @@ List *createModelCommandList(void)
     LIST_ADD(CMD_MODEL_NOLIFE, "nolife");
     LIST_ADD(CMD_MODEL_NOMOVE, "nomove");
     LIST_ADD(CMD_MODEL_NOPAIN, "nopain");
-    LIST_ADD(CMD_MODEL_NOSHADOW, "noshadow");
     LIST_ADD(CMD_MODEL_NOPASSIVEBLOCK, "nopassiveblock");
     LIST_ADD(CMD_MODEL_NOQUAKE, "noquake");
     LIST_ADD(CMD_MODEL_NOREFLECT, "noreflect");
+    LIST_ADD(CMD_MODEL_NOSHADOW, "noshadow");
     LIST_ADD(CMD_MODEL_NOTGRAB, "notgrab");
     LIST_ADD(CMD_MODEL_OFFENSE, "offense");
     LIST_ADD(CMD_MODEL_OFFSCREENKILL, "offscreenkill");

--- a/engine/source/openborscript/commands.h
+++ b/engine/source/openborscript/commands.h
@@ -496,10 +496,10 @@ typedef enum modelCommand
     CMD_MODEL_NOLIFE,
     CMD_MODEL_NOMOVE,
     CMD_MODEL_NOPAIN,
-    CMD_MODEL_NOSHADOW, // Kratus (10-2021) Added new noshadow property
     CMD_MODEL_NOPASSIVEBLOCK,
     CMD_MODEL_NOQUAKE,
     CMD_MODEL_NOREFLECT,
+    CMD_MODEL_NOSHADOW, // Kratus (12-2021) Added new noshadow property, put in alphabetical order
     CMD_MODEL_NOTGRAB,
     CMD_MODEL_OFFENSE,
     CMD_MODEL_OFFSCREENKILL,


### PR DESCRIPTION
# Pull Request
December-2021 updates

## General Description

These two changes fix a bug that randomly causes the engine to crash while trying to get/change an entity property. In addition, there's some minor changes related to code organization, with no changes in the functionality

- Fixed property string names: "animation.handle" to "animation_handle", match with "_ep_animation_handle"
- Fixed property string names: "offscreennoatkfactor" to" offscreen_noatk_factor", match with "_ep_offscreen_noatk_factor"