### PR TITLE
Fix build on modern systems.

### DIFF
--- a/engine/source/ramlib/ram.c
+++ b/engine/source/ramlib/ram.c
@@ -116,7 +116,7 @@ u64 getFreeRam(int byte_size)
 #elif SYMBIAN
     return GetFreeAmount();
 #else
-    struct mallinfo mi = mallinfo();
+    struct mallinfo2 mi = mallinfo2();
 #ifdef _INCLUDE_MALLOC_H_
     // Standard ANSI C Implementation
     return (systemRam - (mi.arena + stackSize)) / byte_size;

--- a/engine/source/utils.c
+++ b/engine/source/utils.c
@@ -304,7 +304,7 @@ void *checkAlloc(void *ptr, size_t size, const char *func, const char *file, int
         writeToLogFile("Out of memory!\n");
         writeToLogFile("Allocation of size %i failed in function '%s' at %s:%i.\n", size, func, file, line);
 #ifndef WIN
-        writeToLogFile("Memory usage at exit: %u\n", mallinfo().arena);
+        writeToLogFile("Memory usage at exit: %u\n", mallinfo2().arena);
 #endif
         borExit(2);
     }


### PR DESCRIPTION
Mallinfo is deprecated. Changed all the occurrences with mallinfo2. Now builds in newer systems. Fixes #243.