### PR TITLE
Feature/macos support

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -159,16 +159,23 @@ BUILD_SDL_IO    = 1
 BUILD_OPENGL    = 1
 BUILD_LOADGL    = 1
 BUILD_VORBIS    = 1
+BUILD_WEBM      = 1
 BUILDING        = 1
 YASM            = yasm
 CC              = $(PREFIX)gcc
 OBJTYPE         = macho
 INCLUDES        = $(DWNDEV)/include \
-                  $(DWNDEV)/include/SDL \
+                  $(DWNDEV)/include/SDL2 \
                   $(SDKPATH)/usr/include/malloc
 LIBRARIES       = $(DWNDEV)/lib
 ifeq ($(findstring darwin10, $(PREFIX)), darwin10)
 ARCHFLAGS       = -arch i386 -arch x86_64
+else ifeq ($(MACHINENAME), x86_64)
+TARGET_ARCH     = x86_64
+ARCHFLAGS       = -arch x86_64
+else ifeq ($(MACHINENAME), arm64)
+#TARGET_ARCH     = arm
+ARCHFLAGS       = -arch arm64
 else
 BUILD_MMX       = 1
 TARGET_ARCH     = x86
@@ -499,18 +506,22 @@ OBJS            = $(MAIN)                                                       
 #----------------------------------------------------------------------------------------------------
 
 CFLAGS 	       += $(addprefix -I", $(addsuffix ", $(INCS))) $(ARCHFLAGS) -D$(TARGET_PLATFORM)
-CFLAGS 	       += -g -Wall -Werror -Wno-format-truncation -Wno-stringop-truncation -fsigned-char -std=gnu99
+CFLAGS 	       += -g -Wall -fsigned-char -std=gnu99
 
+ifndef BUILD_DARWIN
+CFLAGS         +=-Werror -Wno-format-truncation -Wno-stringop-truncation
+endif
 
 ifndef BUILD_DARWIN
 ifdef BUILD_LINUX
 CFLAGS         += -Wno-unused-result `pkg-config sdl2 --cflags`
 endif
+ENABLE_REORDER_BLOCKS=-freorder-blocks
 endif
 
 ifndef BUILD_DEBUG
 CFLAGS 	       += -O2
-CFLAGS 	       += -fno-ident -freorder-blocks
+CFLAGS 	       += -fno-ident $(ENABLE_REORDER_BLOCKS)
 ifndef BUILD_AMD64
 CFLAGS         += -fomit-frame-pointer
 endif
@@ -533,7 +544,7 @@ endif
 
 
 ifdef BUILD_DARWIN
-CFLAGS 	       += -DLINUX -headerpad_max_install_names -isysroot $(SDKPATH)
+CFLAGS 	       += -DLINUX -isysroot $(SDKPATH)
 endif
 
 
@@ -616,7 +627,7 @@ LIBS           += -Wl,-syslibroot,$(SDKPATH) \
                   -framework Carbon \
                   -framework AudioUnit \
                   -framework IOKit \
-                  -lSDLmain
+                  -lSDL2main
 endif
 
 

--- a/engine/darwin.sh
+++ b/engine/darwin.sh
@@ -23,8 +23,8 @@ IFS='
 '
 
 #copy libs, used to be in build.sh
-lib_copy=(`find ${DWNDEV}/lib -name "libSDL-*.dylib"`)
-lib_copy+=(`find ${DWNDEV}/lib -name "libSDL_gfx.*.dylib"`)
+lib_copy=(`find ${DWNDEV}/lib -name "libSDL2-*.dylib"`)
+lib_copy+=(`find ${DWNDEV}/lib -name "libSDL2_gfx*.dylib"`)
 lib_copy+=(`find ${DWNDEV}/lib -name "libogg.*.dylib"`)
 lib_copy+=(`find ${DWNDEV}/lib -name "libvorbisfile.*.dylib"`)
 lib_copy+=(`find ${DWNDEV}/lib -name "libvorbis.*.dylib"`)
@@ -32,12 +32,12 @@ lib_copy+=(`find ${DWNDEV}/lib -name "libz.[0-9].dylib"`)
 lib_copy+=(`find ${DWNDEV}/lib -name "libpng[0-9][0-9].dylib"`)
 
 for ((i = 0; i < ${#lib_copy[*]}; i = $i + 1)); do
-  cp ${lib_copy[i]} ./releases/DARWIN/OpenBOR.app/Contents/Libraries
+  install -m 0644 ${lib_copy[i]} ./releases/DARWIN/OpenBOR.app/Contents/Libraries
 done
 
 # Order and pairing is critical!!!
-lib_ref_patch=(`find ${DWNDEV}/lib -name "libSDL-*.dylib"`)
-lib_ref_patch+=(`find ${DWNDEV}/lib -name "libSDL_gfx.*.dylib"`)
+lib_ref_patch=(`find ${DWNDEV}/lib -name "libSDL2-*.dylib"`)
+lib_ref_patch+=(`find ${DWNDEV}/lib -name "libSDL2_gfx*.dylib"`)
 lib_ref_patch+=(`find ${DWNDEV}/lib -name "libogg.*.dylib"`)
 lib_ref_patch+=(`find ${DWNDEV}/lib -name "libvorbisfile.*.dylib"`)
 lib_ref_patch+=(`find ${DWNDEV}/lib -name "libogg.*.dylib"`)

--- a/engine/environ.sh
+++ b/engine/environ.sh
@@ -428,7 +428,10 @@ case $1 in
 #                                                                          #
 ############################################################################
 10)
-   if test -e "/opt/mac"; then
+   if test -e "$(command -v brew)"; then
+     export DWNDEV=$(brew --prefix)
+     export SDKPATH=$(xcrun --sdk macosx --show-sdk-path)
+   elif test -e "/opt/mac"; then
      export DWNDEV=/opt/mac
      export SDKPATH=$DWNDEV/SDKs/MacOSX10.4u.sdk
      export PREFIX=i686-apple-darwin8-
@@ -445,9 +448,6 @@ case $1 in
        export SDKPATH=/Developer/SDKs/MacOSX10.6.sdk
      fi
      export PATH=$PATH:DWNDEV/bin
-   elif test -e "$(command -v brew)"; then
-     export DWNDEV=$(brew --prefix)
-     export SDKPATH=$(xcrun --sdk macosx --show-sdk-path)
    fi
    if test $DWNDEV; then
      echo "-------------------------------------------------------"

--- a/engine/environ.sh
+++ b/engine/environ.sh
@@ -445,6 +445,9 @@ case $1 in
        export SDKPATH=/Developer/SDKs/MacOSX10.6.sdk
      fi
      export PATH=$PATH:DWNDEV/bin
+   elif test -e "$(command -v brew)"; then
+     export DWNDEV=$(brew --prefix)
+     export SDKPATH=$(xcrun --sdk macosx --show-sdk-path)
    fi
    if test $DWNDEV; then
      echo "-------------------------------------------------------"

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -20,6 +20,15 @@
 
 #define NaN 0xAAAAAAAA
 
+#define EMPTY_FLASH {\
+        .object_type = OBJECT_TYPE_FLASH,\
+        .layer_adjust = 0,\
+        .layer_source = 0,\
+        .model_block = MODEL_INDEX_NONE,\
+        .model_hit = MODEL_INDEX_NONE,\
+        .z_source = 0\
+}
+
 static const char *E_OUT_OF_MEMORY = "Error: Could not allocate sufficient memory.\n";
 static int DEFAULT_OFFSCREEN_KILL = 3000;
 
@@ -168,15 +177,7 @@ const s_offense default_offense =
     .factor         = 1.f    
 };
 
-const s_flash_properties empty_flash = {
-
-        .object_type = OBJECT_TYPE_FLASH,
-        .layer_adjust = 0,
-        .layer_source = 0,
-        .model_block = MODEL_INDEX_NONE,
-        .model_hit = MODEL_INDEX_NONE,
-        .z_source = 0
-};
+const s_flash_properties empty_flash = EMPTY_FLASH;
 
 const s_hitbox empty_collision_coords = {   .x      = 0,
                                             .y      = 0,
@@ -192,7 +193,7 @@ const s_collision_body empty_collision_body = { .coords = NULL,
                                             .meta_tag = 0 };
 
 const s_body empty_body = { .defense = NULL,
-                            .flash = empty_flash
+    .flash = EMPTY_FLASH
                                 
 };
 
@@ -227,7 +228,7 @@ const s_attack emptyattack =
     .dropv              = { .x = 0,
                             .y = 0,
                             .z = 0},
-    .flash = empty_flash,
+    .flash = EMPTY_FLASH,
     .force_direction    = DIRECTION_ADJUST_NONE,
     .forcemap           = MAP_TYPE_NONE,
     .freeze             = 0,


### PR DESCRIPTION
# Pull Request
Make OpenBOR compiling and working on macOS (again)

## General Description
OpenBOR has dropped support for macOS for years officially. I found a very old post in the forum (https://www.chronocrash.com/forum/threads/mac-version-for-openbor.65/) talking about macOS port.
I basically work everyday on a mac, and seems it is not that hard to make mac port possible(again).

## Changes

- Updated envion.sh, assuming we are using homebrew to get libs for build dependency. 
- Updated Makefile to use SDL2
- Updated Makefile to set arch for both x86_64(Intel Macs) and arm64(M1/M2 Macs)
- Updated Makefile, set some build options, such as removed -Werror
- Updated engine/openbor.c to get rid of "error: initializer element is not a compile-time constant"
- Updated engine/source/utils.c, not using mallinfo on macos, code from the post above.

## How to compile
Tested on M1 mac (macOS 14.2.1 (23C71)) , and Intel mac (macOS 12.7.2 (21G1974))

- Install homebrew, XCode of course
- Install sdl2, sdl2_gfx, libvorbis, libogg, libpng by homebrew (maybe other libs but I did not recall)
- cd into openbor/engine, run build.sh 10
- copy your Paks into releases/DARWIN/OpenBOR.app/Contents/Resources/Paks

## Remarks

- We will need an apple developer id for signing the compiled app if we want to publish it.
- It's OK to close this PR if you decide to not adding macOS support back.