### PR TITLE
Silence unused variable warning for vorbis_fpu within webm library.

### DIFF
--- a/engine/source/webmlib/samplecvt.c
+++ b/engine/source/webmlib/samplecvt.c
@@ -69,6 +69,15 @@ void pack_samples(ogg_int32_t **pcm, short *buffer, int samples, int channels)
 
 #include "vorbisfpu.h"
 
+/**
+ *  Modern nix platforms may or may not have fpu implemented,
+ *  thus the unsused warning should be silenced and is stripped
+ *  away for releases mode.
+*/
+#ifdef LINUX
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
 void pack_samples(float **pcm, short *buffer, int samples, int channels)
 {
     int i, j;


### PR DESCRIPTION
Since vorbis_fpu_set/get are inline functions and are not implemented for most Modern distributions, I prefer to silence the warning versus chopping up the code where these functions are referenced since unused functions and variables are eventually stripped away by linker.