### PR TITLE
Fixed warnings reported by compiler about function signature mismatch.

### DIFF
--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -4201,7 +4201,7 @@ float randf(float max);
 int _makecolour(int r, int g, int b);
 int load_colourmap(s_model *model, char *image1, char *image2);
 int load_palette(unsigned char *pal, char *filename);
-void standard_palette();
+void standard_palette(int immediate);
 void change_system_palette(int palindex);
 void unload_background();
 void lifebar_colors();
@@ -4223,9 +4223,9 @@ s_model *nextplayermodel(s_model *current);
 s_model *prevplayermodel(s_model *current);
 void free_anim(s_anim *anim);
 void free_models();
-int free_model();
+int free_model(s_model *model);
 void cache_attack_hit_sounds(s_collision_attack* head, int load);
-void cache_model_sprites();
+void cache_model_sprites(s_model *m, int ld);
 
 s_drawmethod			*allocate_drawmethod();
 s_projectile			*allocate_projectile();
@@ -4708,7 +4708,7 @@ void safe_set(int *arr, int index, int newkey, int oldkey);
 
 void keyboard_setup_menu(int player);
 void keyboard_setup(int player);
-void inputrefresh();
+void inputrefresh(int playrecmode);
 
 int menu_difficulty();
 void menu_options();

--- a/engine/source/scriptlib/ScriptVariant.h
+++ b/engine/source/scriptlib/ScriptVariant.h
@@ -56,7 +56,7 @@ void StrCache_Clear();
 // int the string cache
 //void StrCache_Init();
 void StrCache_Collect(int index);
-int StrCache_Pop();
+int StrCache_Pop(int length);
 int StrCache_CreateNewFrom(const CHAR *str);
 CHAR *StrCache_Get(int index);
 void ScriptVariant_Clear(ScriptVariant *var);


### PR DESCRIPTION
When compiling for MacOS which has zero warnings disabled, I found the various files had function signature mismatches.  Source has been cleaned up.