### PR TITLE
Only structures written to disk require packing.

### DIFF
--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -1790,8 +1790,6 @@ if(n<1) n = 1;
 //#define     MAX_MOVES             16
 //#define     MAX_MOVE_STEPS        16
 
-#pragma pack(4)
-
  /*
  * Caskey, Damon V.
  * 2022-05-04
@@ -1969,42 +1967,6 @@ typedef struct s_metric_range {
     int max;
     int min;
 } s_metric_range;
-
-typedef struct
-{
-    unsigned compatibleversion;
-    char dName[MAX_NAME_LEN]; // Difficulty Name
-    unsigned level; // Level Number
-    unsigned stage; // Stage
-    unsigned pLives[MAX_PLAYERS]; // Player Lives Left
-    unsigned pCredits[MAX_PLAYERS]; // Player Credits Left
-    unsigned pScores[MAX_PLAYERS]; // Player Scores
-    unsigned credits; // Number Of Credits
-    unsigned times_completed;
-    unsigned which_set;
-    //-------------------new strict save features-----------------------
-    int flag; // 0 useless slot 1 only load level number 2 load player info and level
-    char pName[MAX_PLAYERS][MAX_NAME_LEN];   // player names
-    int pSpawnhealth[MAX_PLAYERS];              // hit points left
-    int pSpawnmp[MAX_PLAYERS];                  // magic points left
-    int pWeapnum[MAX_PLAYERS];                  // weapon
-    int pColourmap[MAX_PLAYERS];                // colour map
-
-    int selectFlag;                             // saved a select.txt infos
-    char allowSelectArgs[MAX_ALLOWSELECT_LEN];      // allowselect arguments
-    char selectMusic[MAX_ARG_LEN];          // select music arguments
-    char selectBackground[MAX_ARG_LEN];     // select background arguments
-    char selectLoad[MAX_SELECT_LOADS][MAX_ARG_LEN];           // select load arguments
-    int selectLoadCount;
-    char selectSkipSelect[MAX_ARG_LEN];     // skipselect arguments
-} s_savelevel;
-
-typedef struct
-{
-    unsigned compatibleversion;
-    unsigned highsc[10];
-    char hscoren[10][MAX_NAME_LEN];
-} s_savescore;
 
 typedef struct
 {
@@ -4052,9 +4014,6 @@ typedef struct ArgList
     char *args[MAX_ARG_COUNT];
 } ArgList;
 
-#pragma pack()
-
-
 #define GET_ARG(z) (arglist.count > z ? arglist.args[z] : "")
 #define GET_ARG_LEN(z) (arglist.count > z ? arglist.arglen[z] : 0)
 #define GET_ARGP(z) (arglist->count > z ? arglist->args[z] : "")
@@ -4731,6 +4690,49 @@ int freeRecordedInputs(void);
 a_playrecstatus* init_input_recorder(void);
 void free_input_recorder(void);
 void goto_mainmenu(int);
+
+/**
+ *  Only structures written to disk need to be packed.
+ */
+#pragma pack(1)
+
+typedef struct
+{
+    unsigned compatibleversion;
+    char dName[MAX_NAME_LEN]; // Difficulty Name
+    unsigned level; // Level Number
+    unsigned stage; // Stage
+    unsigned pLives[MAX_PLAYERS]; // Player Lives Left
+    unsigned pCredits[MAX_PLAYERS]; // Player Credits Left
+    unsigned pScores[MAX_PLAYERS]; // Player Scores
+    unsigned credits; // Number Of Credits
+    unsigned times_completed;
+    unsigned which_set;
+    //-------------------new strict save features-----------------------
+    int flag; // 0 useless slot 1 only load level number 2 load player info and level
+    char pName[MAX_PLAYERS][MAX_NAME_LEN];   // player names
+    int pSpawnhealth[MAX_PLAYERS];              // hit points left
+    int pSpawnmp[MAX_PLAYERS];                  // magic points left
+    int pWeapnum[MAX_PLAYERS];                  // weapon
+    int pColourmap[MAX_PLAYERS];                // colour map
+
+    int selectFlag;                             // saved a select.txt infos
+    char allowSelectArgs[MAX_ALLOWSELECT_LEN];      // allowselect arguments
+    char selectMusic[MAX_ARG_LEN];          // select music arguments
+    char selectBackground[MAX_ARG_LEN];     // select background arguments
+    char selectLoad[MAX_SELECT_LOADS][MAX_ARG_LEN];           // select load arguments
+    int selectLoadCount;
+    char selectSkipSelect[MAX_ARG_LEN];     // skipselect arguments
+} s_savelevel;
+
+typedef struct
+{
+    unsigned compatibleversion;
+    unsigned highsc[10];
+    char hscoren[10][MAX_NAME_LEN];
+} s_savescore;
+
+#pragma pack()
 
 extern s_savelevel   *savelevel;
 extern s_savescore    savescore;

--- a/engine/source/savedata.h
+++ b/engine/source/savedata.h
@@ -12,6 +12,11 @@
 #define     MAX_PLAYERS         4
 #define     MAX_BTN_NUM         13
 
+/**
+ *  Only structures written to disk need to be packed.
+ */
+#pragma pack(1)
+
 typedef struct
 {
     unsigned compatibleversion;
@@ -47,6 +52,8 @@ typedef struct
     int is_touchpad_vibration_enabled;
 #endif
 } s_savedata;
+
+#pragma pack()
 
 extern s_savedata     savedata;
 


### PR DESCRIPTION
Pack as a whole should not be applied to all structures as they will cause cpu performance impacts due to non-native alignment.  Instead only structures that are saved to disk or read from disk should have packing applied in order to guarantee the size of the structure being written is consistent across platforms. 


This will break current saved configurations though... but moving forward they should all be consistently packed across all targets and saves can be shared across different platforms as long as endianness matches and CPU bits.