### PR TITLE
Delay before update() to reduce input latency when vsync is enabled

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -559,11 +559,11 @@ endif
 
 ifdef BUILD_SDL
 ifeq ($(findstring DGE, $(SDKPATH)), DGE)
-LIBS           += -lSDL -lSDL_gfx -lts # Kratus (01-2023) Added a FPS limit option in the video settings
+LIBS           += -lSDL -lts
 else
 COMMA		=,
 RPATH_LIBS	= $(addprefix -Wl$(COMMA)-rpath$(COMMA),"$(LIBRARIES)")
-LIBS	       += $(RPATH_LIBS) -lSDL2 -lSDL2_gfx # Kratus (01-2023) Added a FPS limit option in the video settings
+LIBS	       += $(RPATH_LIBS) -lSDL2
 
 ifdef CROSSCOMPILE_LINUX_WIN
 LIBS	       += -lsetupapi

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -45731,20 +45731,22 @@ void update(int ingame, int usevwait)
     int i = 0;
     int p_keys = 0;
 
+#if SDL
     if (savedata.vsync)
     {
-        u64 update_start = timer_uticks();
-        int refresh_rate = video_current_refresh_rate();
-        s64 target_time = update_start + 1000000/refresh_rate - 3000;
-        writeToLogFile("update_start=%llu target_time=%lli time_to_wait=%lli refresh_rate=%i\n", update_start, target_time, target_time - update_start, refresh_rate);
+        // To reduce input latency, wait until the last 3 ms (3000 μs) of the current
+        // frame to read inputs or do anything else. We can get away with this because
+        // the CPUs of all modern computers - even phones and low-end/outdated PCs -
+        // are complete overkill for OpenBOR's needs.
+        s64 target_time = timer_uticks() + 1000000/video_current_refresh_rate() - 3000;
         u64 current_time = timer_uticks();
         while (current_time < target_time)
         {
             usleep(target_time - current_time);
             current_time = timer_uticks();
         }
-        writeToLogFile("done waiting\n");
     }
+#endif
 
     getinterval();
     if(playrecstatus->status == A_REC_PLAY && !_pause && level) if ( !playRecordedInputs() ) stopRecordInputs();

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -45733,11 +45733,11 @@ void update(int ingame, int usevwait)
 #if SDL
     if (savedata.fpslimit == 1) // vsync enabled
     {
-        // To reduce input latency, wait until the last 3 ms (3000 μs) of the current
+        // To reduce input latency, wait until the last 4 ms (4000 μs) of the current
         // frame to read inputs or do anything else. We can get away with this because
         // the CPUs of all modern computers - even phones and low-end, outdated PCs -
         // are complete overkill for OpenBOR's needs.
-        s64 target_time = timer_uticks() + 1000000/video_current_refresh_rate() - 3000;
+        s64 target_time = timer_uticks() + 1000000/video_current_refresh_rate() - 4000;
         u64 current_time = timer_uticks();
         while (current_time < target_time)
         {

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -45735,11 +45735,13 @@ void update(int ingame, int usevwait)
     {
         u64 update_start = timer_uticks();
         int refresh_rate = video_current_refresh_rate();
-        u64 target_time = update_start + 1000000/refresh_rate - 3000;
+        s64 target_time = update_start + 1000000/refresh_rate - 3000;
+        writeToLogFile("update_start=%llu target_time=%lli time_to_wait=%lli refresh_rate=%i\n", update_start, target_time, target_time - update_start, refresh_rate);
         while (timer_uticks() < target_time)
         {
             usleep(target_time - timer_uticks());
         }
+        writeToLogFile("done waiting\n");
     }
 
     getinterval();

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -45731,6 +45731,17 @@ void update(int ingame, int usevwait)
     int i = 0;
     int p_keys = 0;
 
+    if (savedata.vsync)
+    {
+        u64 update_start = timer_uticks();
+        int refresh_rate = video_current_refresh_rate();
+        u64 target_time = update_start + 1000000/refresh_rate - 3000;
+        while (timer_uticks() < target_time)
+        {
+            usleep(target_time - timer_uticks());
+        }
+    }
+
     getinterval();
     if(playrecstatus->status == A_REC_PLAY && !_pause && level) if ( !playRecordedInputs() ) stopRecordInputs();
     inputrefresh(playrecstatus->status);

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -45737,9 +45737,11 @@ void update(int ingame, int usevwait)
         int refresh_rate = video_current_refresh_rate();
         s64 target_time = update_start + 1000000/refresh_rate - 3000;
         writeToLogFile("update_start=%llu target_time=%lli time_to_wait=%lli refresh_rate=%i\n", update_start, target_time, target_time - update_start, refresh_rate);
-        while (timer_uticks() < target_time)
+        u64 current_time = timer_uticks();
+        while (current_time < target_time)
         {
-            usleep(target_time - timer_uticks());
+            usleep(target_time - current_time);
+            current_time = timer_uticks();
         }
         writeToLogFile("done waiting\n");
     }

--- a/engine/openbor.h
+++ b/engine/openbor.h
@@ -63,7 +63,7 @@
 			"\n" \
 			"Special thanks to SEGA and SNK.\n\n"
 
-#define		COMPATIBLEVERSION	0x00033748
+#define		COMPATIBLEVERSION	0x00033749
 #define		CV_SAVED_GAME		0x00033747
 #define		CV_HIGH_SCORE		0x00033747
 #define     GAME_SPEED          200

--- a/engine/sdl/opengl.c
+++ b/engine/sdl/opengl.c
@@ -254,7 +254,7 @@ int video_gl_set_mode(s_videomodes videomodes)
 	}
 
 	// try to disable vertical retrace syncing (VSync)
-	if(SDL_GL_SetSwapInterval(!!savedata.vsync) < 0)
+	if(SDL_GL_SetSwapInterval(savedata.fpslimit == 1) < 0)
 	{
 		printf("Warning: can't disable vertical retrace sync (%s)...\n", SDL_GetError());
 	}
@@ -394,11 +394,7 @@ int video_gl_copy_screen(s_videosurface* surface)
 	// display the rendered frame on the screen
 	SDL_GL_SwapWindow(window);
 
-	// Kratus (01-2023) Added a FPS limit option in the video settings
-	#if WIN || LINUX
-	if(savedata.fpslimit){SDL_framerateDelay(&framerate_manager);}
-
-	#endif
+	if (savedata.fpslimit >= 2) FramerateDelay();
 
 	return 1;
 }

--- a/engine/sdl/video.c
+++ b/engine/sdl/video.c
@@ -303,6 +303,14 @@ int video_display_yuv_frame(void)
 	return 1;
 }
 
+int video_current_refresh_rate()
+{
+    SDL_DisplayMode display_mode;
+    if (SDL_GetCurrentDisplayMode(SDL_GetWindowDisplayIndex(window), &display_mode) != 0)
+        return 60;
+    return display_mode.refresh_rate;
+}
+
 void vga_vwait(void)
 {
 	static int prevtick = 0;

--- a/engine/sdl/video.h
+++ b/engine/sdl/video.h
@@ -18,6 +18,7 @@ extern u8 pDeltaBuffer[480 * 2592];
 extern int opengl;
 
 int SetVideoMode(int, int, int, bool);
+void FramerateDelay();
 
 // Frees all VESA shit when returning to textmode
 int video_set_mode(s_videomodes);

--- a/engine/sdl/video.h
+++ b/engine/sdl/video.h
@@ -33,5 +33,7 @@ int video_setup_yuv_overlay(const yuv_video_mode*);
 int video_prepare_yuv_frame(yuv_frame*);
 int video_display_yuv_frame(void);
 
+int video_current_refresh_rate();
+
 #endif
 

--- a/engine/source/savedata.h
+++ b/engine/source/savedata.h
@@ -35,8 +35,7 @@ typedef struct
     int fullscreen; // Window or Full Screen Mode
     int stretch; // Stretch (1) or preserve aspect ratio (0) in fullscreen mode
     int screen[1][2];
-    int vsync; // Sync to monitor refresh (1) or don't (0)
-    int fpslimit; // Kratus (01-2023) Added a FPS limit option in the video settings
+    int fpslimit; // Sync to monitor refresh (1), limit to 200/500 FPS (2, 3) or don't (0)
 #if SDL
     int usegl; // 1 if OpenGL is preferred over SDL software blitting
     float hwscale; // Scale factor for OpenGL


### PR DESCRIPTION
Reduces input latency when vsynced by not reading inputs until 4 ms before frame submission.

Also drops the dependency on SDL_gfx, replaces the SDL_gfx framerate limiter with a newly implemented simple limiter, and merges the "VSync" and "FPS limit" video options together. The possible settings for the newly combined "FPS limit" option are VSync (default), 200, 500, and disabled.