### PR TITLE
Fix GCC 13 compiler errors

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -29982,7 +29982,7 @@ int player_test_touch(entity *ent, entity *item)
     return test_item(ent, item);
 }
 
-entity *find_ent_here(entity *exclude, float x, float z, e_entity_type types, int (*test)(entity *, entity *))
+entity *find_ent_here(entity *exclude, float x, float z, int types, int (*test)(entity *, entity *))
 {
     int i;
     for(i = 0; i < ent_max; i++)
@@ -30265,7 +30265,7 @@ int set_riseattack(entity *iRiseattack, int type, int reset)
     return 1;
 }
 
-int set_blockpain(entity *ent, e_attack_types attack_type, int reset)
+int set_blockpain(entity *ent, int attack_type, int reset)
 {
     e_animations animation;
 

--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -29376,9 +29376,9 @@ void display_ents()
                 {
                     s_anim *anim = e->animation;
 
-                    if ( anim->platform[e->animpos] )
+                    if ( anim->platform[e->animpos][PLATFORM_HEIGHT] )
                     {
-                        if ( anim->platform[e->animpos][PLATFORM_HEIGHT] ) eplatheight += anim->platform[e->animpos][PLATFORM_HEIGHT];
+                        eplatheight += anim->platform[e->animpos][PLATFORM_HEIGHT];
                     }
                 }
                 if ( e->modeldata.size.y && eplatheight <= 0 ) eheight += e->modeldata.size.y;


### PR DESCRIPTION
Make OpenBOR compile with GCC 13. For the context, I try to make a OpenBOR Flatpak - hopefully @DCurrent is not against :slightly_smiling_face: .

I'm don't know the project nor C well, please review this PR carefully - this may not be the right fixes.

Fixes https://github.com/DCurrent/openbor/issues/277
Fixes https://github.com/DCurrent/openbor/issues/278