### PR TITLE
Move malloc.h behind ifndef DARWIN

### DIFF
--- a/engine/source/pnglib/savepng.c
+++ b/engine/source/pnglib/savepng.c
@@ -7,9 +7,13 @@
  */
 
 #include <png.h>
-#include <malloc.h>
 #include "globals.h"
 #include "screen.h"
+#ifndef DARWIN
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 void savepng(const char *filename, s_screen *screen, u8 *pal)
 {

--- a/engine/source/preprocessorlib/pp_parser.c
+++ b/engine/source/preprocessorlib/pp_parser.c
@@ -19,12 +19,16 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <time.h>
-#include <malloc.h>
 #include <errno.h>
 #include "List.h"
 #include "pp_parser.h"
 #include "pp_expr.h"
 #include "borendian.h"
+#ifndef DARWIN
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #if PP_TEST // using pp_test.c to test the preprocessor functionality; OpenBOR functionality is not available
 #undef printf

--- a/engine/source/ramlib/ram.c
+++ b/engine/source/ramlib/ram.c
@@ -26,6 +26,7 @@
 #include <mach/task.h>
 #include <mach/mach.h>
 #include <mach/mach_init.h>
+#include <stdlib.h>
 #elif LINUX
 #include <sys/sysinfo.h>
 #include <unistd.h>
@@ -38,7 +39,9 @@
 #include <stdlib.h>
 #endif
 
+#ifndef DARWIN
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <stdio.h>
 #include "globals.h"

--- a/engine/source/utils.c
+++ b/engine/source/utils.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-#include <malloc.h>
 #include <locale.h>
 #include <math.h>
 
@@ -21,6 +20,12 @@
 #include "packfile.h"
 
 #include <dirent.h>
+
+#ifndef DARWIN
+#include <malloc.h>
+#else
+#include <stdlib.h>
+#endif
 
 #ifdef SDL
 #include <unistd.h>


### PR DESCRIPTION
# Pull Request

## General Description
Fixes building on macOS. malloc.h isn't present and wants stdlib.h instead.