### PR TITLE
Add Options in Pause menu

### DIFF
--- a/engine/openbor.c
+++ b/engine/openbor.c
@@ -21631,7 +21631,8 @@ void pausemenu()
 
         if(newkeys & (FLAG_MOVEUP | FLAG_MOVEDOWN))
         {
-            if(newkeys == FLAG_MOVEUP) {
+            if(newkeys == FLAG_MOVEUP)
+            {
                 if (pauselector == CONTINUE)
                 {
                     pauselector = END_GAME;


### PR DESCRIPTION
## General Description
This adds `Options` menu item in the `Pause` screen as suggested in #314

Fixes: #314

Screenshot:


<img width="668" height="546" alt="Screenshot from 2025-11-06 13-44-33" src="https://github.com/user-attachments/assets/90ed307d-ff5f-4b8f-bc40-169c1dbdbfbe" />


<img width="668" height="546" alt="Screenshot from 2025-11-06 09-24-08" src="https://github.com/user-attachments/assets/4985cd31-5ae8-4e2d-88b8-631e8cc064e8" />
